### PR TITLE
add hash key to key schema

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -2,39 +2,26 @@ var AWS = require('aws-sdk');
 
 AWS.config.update({
     accessKeyId: 'fake',
-    accessSecretKey: 'fake',
-    endpoint:new AWS.Endpoint('http://localhost:4567'),
+    secretAccessKey: 'fake',
     region:'us-east-1'
 });
 
-var dynamo = new AWS.DynamoDB();
+var dynamo = new AWS.DynamoDB({endpoint: new AWS.Endpoint('http://localhost:4567')});
 
 var geoTable = {
     'TableName': 'geo',
     'AttributeDefinitions': [
-        {'AttributeName': 'id', 'AttributeType': 'S'},
-        {'AttributeName': 'data', 'AttributeType': 'S'}
+        {'AttributeName': 'layer', 'AttributeType': 'S'},
+        {'AttributeName': 'id', 'AttributeType': 'S'}
     ],
     'KeySchema': [
+        {'AttributeName': 'layer', 'KeyType': 'HASH'},
         {'AttributeName': 'id', 'KeyType': 'RANGE'}
     ],
     'ProvisionedThroughput': {
         'ReadCapacityUnits': 5,
         'WriteCapacityUnits': 50
-    },
-    'GlobalSecondaryIndexes': [
-        {
-            'IndexName': 'geo-index',
-            'KeySchema': [
-                { 'AttributeName': 'id', 'KeyType': 'RANGE' }
-            ],
-            'Projection': { 'ProjectionType': 'KEYS_ONLY' },
-            'ProvisionedThroughput': {
-                'ReadCapacityUnits': 5,
-                'WriteCapacityUnits': 50
-            }
-        }
-    ]
+    }
 };
 
 module.exports.createTable = function(client, cb) {


### PR DESCRIPTION
the table key schema requires a hash key. Add `layer` to be the hash key, with the idea that the hash key would define the data layer.

removed the secondary index, since the primary index already index id. 

fixes #7 
