### PR TITLE
Add updated timestamp to metadata record

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -57,7 +57,8 @@ module.exports = function(dyno, dataset) {
             east: -180,
             north: -90,
             count: 0,
-            size: 0
+            size: 0,
+            updated: +new Date()
         };
 
         var opts = { expected: {} }
@@ -76,7 +77,8 @@ module.exports = function(dyno, dataset) {
             east: -180,
             north: -90,
             count: 0,
-            size: 0
+            size: 0,
+            updated: +new Date()
         };
 
         var query = { dataset: { EQ: dataset }, id: { BEGINS_WITH: 'id!' } },
@@ -110,6 +112,7 @@ module.exports = function(dyno, dataset) {
         bounds.forEach(function(bound, i) {
             var item = { put: {} };
             item.put[labels[i]] = bound;
+            item.put.updated = +new Date();
 
             var opts = { expected: {} };
             opts.expected[labels[i]] = {
@@ -126,7 +129,8 @@ module.exports = function(dyno, dataset) {
     // Increment/decrement the specified properties
     // This operation **will not** create a metadata record if one does not exist
     metadata.adjustProperties = function(properties, callback) {
-        var item = { add: properties };
+        var item = { add: properties, put: {} };
+        item.put.updated = +new Date();
 
         var opts = { expected: {} }
         opts.expected.id = { ComparisonOperator: 'NOT_NULL' };

--- a/test/index.js
+++ b/test/index.js
@@ -746,7 +746,7 @@ test('metadata: adjust bounds', function(t) {
             count: initial.count,
             size: initial.size
         };
-        t.deepEqual(info, expected, 'updated metadata correctly');
+        t.deepEqual(_.omit(info, 'updated'), expected, 'updated metadata correctly');
         t.end();
     }
 });
@@ -919,10 +919,12 @@ test('metadata: calculate dataset info', function(t) {
 
         metadata.calculateInfo(function(err, info) {
             t.ifError(err, 'calculated');
-            t.deepEqual(info, expected, 'returned expected info');
+            t.ok(info.updated, 'has updated date');
+            t.deepEqual(_.omit(info, 'updated'), expected, 'returned expected info');
             cardboard.getDatasetInfo(dataset, function(err, info) {
                 t.ifError(err, 'got metadata');
-                t.deepEqual(info, expected, 'got expected info from dynamo');
+                t.ok(info.updated, 'has updated date');
+                t.deepEqual(_.omit(info, 'updated'), expected, 'got expected info from dynamo');
                 t.end();
             });
         });
@@ -963,7 +965,8 @@ test('insert idaho & check metadata', function(t) {
             count : 1,
             size : info.size
         }
-        t.deepEqual(info, expected, 'expected metadata');
+        t.ok(info.updated, 'has updated date');
+        t.deepEqual(_.omit(info, 'updated'), expected, 'expected metadata');
         t.end();
     }
 });
@@ -1005,7 +1008,8 @@ test('insert many idaho features & check metadata', function(t) {
           count : features.length,
           size : expectedSize
         }
-        t.deepEqual(info, expected, 'expected metadata');
+        t.ok(info.updated, 'has updated date');
+        t.deepEqual(_.omit(info, 'updated'), expected, 'expected metadata');
         t.end();
     }
 });
@@ -1048,8 +1052,9 @@ test('insert many idaho features, delete one & check metadata', function(t) {
           north : expectedBounds[3],
           count : features.length - 1,
           size : expectedSize
-        }
-        t.deepEqual(info, expected, 'expected metadata');
+        };
+        t.ok(info.updated, 'has updated date');
+        t.deepEqual(_.omit(info, 'updated'), expected, 'expected metadata');
         t.end();
     }
 });
@@ -1100,8 +1105,9 @@ test('insert idaho feature, update & check metadata', function(t) {
           north : expectedBounds[3],
           count : 1,
           size : expectedSize
-        }
-        t.deepEqual(info, expected, 'expected metadata');
+        };
+        t.ok(info.updated, 'has updated date');
+        t.deepEqual(_.omit(info, 'updated'), expected, 'expected metadata');
         t.end();
     }
 });


### PR DESCRIPTION
Allows caller to see how old the metadata for a particular dataset is.
