### PR TITLE
Add bounds, id, and s3url to query attributes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,7 +225,6 @@ module.exports = function Cardboard(c) {
             var options = {
                 pages: 0,
                 index: 'cell',
-                attributes: ['val', 'geometryid'],
                 filter : {
                     west: { 'LE': input[2] },
                     east: { 'GE': input[0] },


### PR DESCRIPTION
Fixes #63. If this is better fixed in dyno (https://github.com/mapbox/dyno/issues/23), @mick, then let's amend or delete this PR.
