### PR TITLE
Remove redundant tableName from createTable

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,9 +113,9 @@ module.exports = function Cardboard(c) {
         });
     };
 
-    cardboard.createTable = function(tableName, callback) {
+    cardboard.createTable = function(callback) {
         var table = require('./lib/table.json');
-        table.TableName = tableName;
+        table.TableName = c.table;
         dyno.createTable(table, callback);
     };
 

--- a/test/index.js
+++ b/test/index.js
@@ -43,7 +43,7 @@ function setup() {
         dynalite.listen(4567, function() {
             t.pass('dynalite listening');
             var cardboard = Cardboard(config);
-            cardboard.createTable(config.table, function(err, resp){
+            cardboard.createTable(function(err, resp){
                 t.pass('table created');
                 t.end();
             });


### PR DESCRIPTION
Don't need to provide the table name that was already provided to the constructor.