### PR TITLE
Deduplicate split query tiles.

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,19 +237,14 @@ module.exports = function Cardboard(c) {
             return memo;
         }, []);
 
-        var split_tiles = bboxes.map(function(bbox) {
-            return tilebelt.bboxToTile(bbox);
-        });
+        var tiles = uniq(
+            bboxes.map(function(bbox) { return tilebelt.bboxToTile(bbox); }),
+            function(a, b) { return !tilebelt.tilesEqual(a, b); });
 
         // Dedupe.
-        var tiles = _.clone(split_tiles);
         uniq(tiles, function(a, b) {
                 return !tilebelt.tilesEqual(a, b);
             });
-
-        if (tiles.length != split_tiles.length) {
-            console.log(JSON.stringify(split_tiles) + " deduped to " + JSON.stringify(tiles));
-        }
 
         tiles.forEach(function(tile) {
             var tileKey = tilebelt.tileToQuadkey(tile);


### PR DESCRIPTION
Console.log() calls for debugging, to be removed.
