### PR TITLE
Truncate extents of loaded items

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ module.exports = function Cardboard(c) {
         }
 
     };
+
     function putFeature(feature, dataset, callback) {
         var isUpdate = feature.hasOwnProperty('id'),
             f = isUpdate ? _.clone(feature) : _.extend({ id: cuid() }, feature),
@@ -84,10 +85,10 @@ module.exports = function Cardboard(c) {
             id: 'id!' + primary,
             cell: 'cell!' + cell,
             size: info.size,
-            west: info.west,
-            south: info.south,
-            east: info.east,
-            north: info.north,
+            west: truncateNum(info.west),
+            south: truncateNum(info.south),
+            east: truncateNum(info.east),
+            north: truncateNum(info.north),
             s3url: ['s3:/', bucket, s3Key].join('/')
         };
 
@@ -358,4 +359,10 @@ function featureCollection(features) {
         type: 'FeatureCollection',
         features: features || []
     };
+}
+
+function truncateNum(num, digits) {
+    digits = digits || 6;
+    var exp = Math.pow(10, digits);
+    return Math.round(exp * num) / exp;
 }

--- a/test/indexing.js
+++ b/test/indexing.js
@@ -82,6 +82,36 @@ test('insert, get by primary index', function(t) {
 test('teardown', s.teardown);
 
 test('setup', s.setup);
+test('insert wildly precise feature', function(t) {
+    var cardboard = Cardboard(config);
+    var d = {
+            "geometry": {
+            "coordinates": [
+                0.987654321,
+                0.123456789
+            ],
+            "type": "Point"
+        },
+        "properties": {},
+        "type": "Feature"
+    };
+
+    cardboard.put(d, 'default', function(err, res) {
+        t.ifError(err, 'inserted without error');
+        dyno.getItem({ dataset: 'default', id: 'id!' + res[0] }, function(err, item) {
+            t.ifError(err, 'got item');
+            if (err) return t.end();
+            t.equal(item.west, 0.987654, 'correct west attr');
+            t.equal(item.east, 0.987654, 'correct east attr');
+            t.equal(item.north, 0.123457, 'correct north attr');
+            t.equal(item.south, 0.123457, 'correct south attr');
+            t.end();
+        });
+    });
+});
+test('teardown', s.teardown);
+
+test('setup', s.setup);
 test('insert non-string usid', function(t) {
     var cardboard = Cardboard(config);
     cardboard.put(featureCollection([


### PR DESCRIPTION
In the case of a feature with ridiculous coordinate precision, geojson-extent gives us a ridiculously precise bbox. The bounds are passed into dynamodb as `west`, `south`, `east` and `north` attributes, but if given that much precision dynamo bails with a `ValidationError: Number underflow` error. 

I think it should be fine truncating these values to 6 decimal places: they are only used when computing the bbox for a dataset and so they don't need to be terribly precise.
