### PR TITLE
preconfigured dyno

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,11 +25,8 @@ module.exports = function Cardboard(c) {
 
     // allow for passed in config object to override s3 objects for mocking in tests
     var s3 = c.s3 || new AWS.S3(c);
-    var creds = new AWS.EC2MetadataCredentials({httpOptions: { timeout: 5000 }});
-    creds.get(function(err) {
-        if(!err && creds) s3.config.credentials= creds;
-    });
-    var dyno = Dyno(c);
+    // pass in a pre configured dyno object, or create one based on config
+    var dyno = c.dyno || Dyno(c);
     if (!c.bucket) throw new Error('No bucket set');
     var bucket = c.bucket;
     if (!c.prefix) throw new Error('No s3 prefix set');
@@ -176,7 +173,6 @@ module.exports = function Cardboard(c) {
     cardboard.list = function(dataset, callback) {
         var query = { dataset: { EQ: dataset }, id: { BEGINS_WITH: 'id!' } },
             opts = { pages: 0 };
-
         dyno.query(query, opts, function(err, items) {
             if (err) return callback(err);
             resolveFeatures(items, function(err, features) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cuid": "^1.2.4",
     "debug": "~1.0.3",
     "dotenv": "^0.4.0",
-    "dyno": "~0.7.4",
+    "dyno": "mapbox/dyno#double-dyno",
     "geobuf": "0.2.3",
     "geojson-extent": "^0.1.0",
     "geojson-normalize": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cuid": "^1.2.4",
     "debug": "~1.0.3",
     "dotenv": "^0.4.0",
-    "dyno": "mapbox/dyno#double-dyno",
+    "dyno": "0.11.0",
     "geobuf": "0.2.3",
     "geojson-extent": "^0.1.0",
     "geojson-normalize": "0.0.0",

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,47 @@
+var test = require('tap').test,
+    fs = require('fs'),
+    Cardboard = require('../'),
+    _ = require('lodash'),
+    Dyno = require('dyno');
+
+var s = require('./setup');
+var config = s.config;
+
+function featureCollection(features) {
+    return  {
+        type: 'FeatureCollection',
+        features: features || []
+    };
+}
+
+test('setup', function(t){ s.setup(t, true); });
+test('pass preconfigured dyno object', function(t) {
+
+    var omitConfig = _.omit(config, ['accessKeyId', 'secretAccessKey', 'table', 'endpoint', 'region']);
+
+    var dynoconfig = {
+        accessKeyId: 'fake',
+        secretAccessKey: 'fake',
+        region: 'us-east-1',
+        table: 'test-cardboard-write',
+        endpoint: 'http://localhost:4567'
+    };
+
+    omitConfig.dyno = Dyno.multi(dynoconfig, dynoconfig);
+    var cardboard = Cardboard(omitConfig);
+    var geojson = featureCollection([{type: 'Feature', properties: {}, geometry: {type: 'Point', coordinates:[1,2]}}]);
+
+    cardboard.put(geojson, 'default', featurePut);
+
+    function featurePut(err) {
+        t.notOk(err);
+
+        cardboard.list('default', function(err, items) {
+            t.equal(err, null);
+            delete items.features[0].id;
+            t.deepEqual(items, geojson, 'one result');
+            t.end();
+        });
+    }
+});
+test('teardown', s.teardown);

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,3 @@
+require('./config');
 require('./indexing');
 require('./bbox_query');


### PR DESCRIPTION
allows for a preconfigured dyno to be passed in the cardboard config.

```
var dyno = Dyno(config);
var cardboard = Cardboard({dyno:dyno});
```

This is useful for using [`Dyno.multi`](https://github.com/mapbox/dyno/pull/54)