### PR TITLE
return error if feature is not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ module.exports = function Cardboard(c) {
 
         dyno.getItem(key, function(err, item) {
             if (err) return callback(err);
-            if (!item) return callback(null, featureCollection());
+            if (!item) return callback(new Error('Feature does not exist'));
             resolveFeature(item, function(err, feature) {
                 if (err) return callback(err);
                 callback(null, featureCollection([feature]));

--- a/index.js
+++ b/index.js
@@ -35,6 +35,12 @@ module.exports = function Cardboard(c) {
 
     cardboard.put = function(featureCollection, dataset, callback) {
         var featureCollection = geojsonNormalize(featureCollection);
+        // reject nested objects
+        featureCollection.features.forEach(function(f) {
+          for (var prop in f.properties) {
+            if (typeof f.properties[prop] === "object") return callback(new Error('Does not support nested objects'));
+          }
+        });
 
         // if the feature is an update, check upfront that they exist, we can fail them
         // early.

--- a/index.js
+++ b/index.js
@@ -124,13 +124,13 @@ module.exports = function Cardboard(c) {
 
     cardboard.del = function(primary, dataset, callback) {
         var key = { dataset: dataset, id: 'id!' + primary };
-        dyno.getItem(key, function(err, item) {
-            if (err) return callback(err);
-            if (!item) return callback(new Error('Feature does not exist'));
-            dyno.deleteItems([ key ], function(err, res, data) {
-                if (err) return callback(err, true);
-                else callback();
-            });
+        var opts = { expected: {
+            id: 'NOT_NULL'
+        } }
+        dyno.deleteItem(key, opts, function(err, res) {
+            if (err && err.code === 'ConditionalCheckFailedException') return callback(new Error('Feature does not exist'));
+            if (err) return callback(err, true);
+            else callback();
         });
     };
 

--- a/index.js
+++ b/index.js
@@ -124,10 +124,13 @@ module.exports = function Cardboard(c) {
 
     cardboard.del = function(primary, dataset, callback) {
         var key = { dataset: dataset, id: 'id!' + primary };
-
-        dyno.deleteItems([ key ], function(err) {
-            if (err) return callback(err, true);
-            else callback();
+        dyno.getItem(key, function(err, item) {
+            if (err) return callback(err);
+            if (!item) return callback(new Error('Feature does not exist'));
+            dyno.deleteItems([ key ], function(err, res, data) {
+                if (err) return callback(err, true);
+                else callback();
+            });
         });
     };
 


### PR DESCRIPTION
`cardboard.get` returns an error instead of empty feature collection if a feature does not exist.

cc/ @willwhite @mick 