### PR TITLE
reject nested objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,12 @@ module.exports = function Cardboard(c) {
 
     cardboard.put = function(featureCollection, dataset, callback) {
         var featureCollection = geojsonNormalize(featureCollection);
-
+        // reject nested objects
+        featureCollection.features.forEach(function(f) {
+            for (var prop in f.properties) {
+                if (typeof f.properties[prop] === "object") return callback(new Error('Does not support nested objects'));
+            }
+        });
         // if the feature is an update, check upfront that they exist, we can fail them
         // early.
         var q = queue(150);

--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ module.exports = function Cardboard(c) {
         // reject nested objects
         featureCollection.features.forEach(function(f) {
             for (var prop in f.properties) {
-                if (typeof f.properties[prop] === "object") return callback(new Error('Does not support nested objects'));
+                if (typeof f.properties[prop] === 'object') {
+                    return callback(new Error('Does not support nested objects'));
+                }
             }
         });
         // if the feature is an update, check upfront that they exist, we can fail them

--- a/test/indexing.js
+++ b/test/indexing.js
@@ -1168,7 +1168,7 @@ test('setup', s.setup);
 test('insert idaho feature, update & check metadata', function(t) {
     var cardboard = new Cardboard(config);
     var original = geojsonFixtures.featurecollection.idaho.features[0];
-    var edited = geojsonFixtures.feature.one;
+    var edited = geojsonFixtures.featurecollection.idaho.features[1];
 
     var expectedSize;
     var expectedBounds = geojsonExtent({

--- a/test/indexing.js
+++ b/test/indexing.js
@@ -171,6 +171,32 @@ test('insert non-string usid', function(t) {
 test('teardown', s.teardown);
 
 test('setup', s.setup);
+test('insert feature with object property', function(t) {
+    var cardboard = Cardboard(config);
+    var d = {
+        "geometry": {
+            "coordinates": [
+                0,
+                0
+            ],
+            "type": "Point"
+        },
+        "properties": {
+            "prop0": "0",
+            "prop1": { "nested": "object"}
+        },
+        "type": "Feature"
+    };
+
+    cardboard.put(d, 'default', function(err, res) {
+        t.ok(err, 'should return an error');
+        t.equal(err.message, 'Does not support nested objects');
+        t.end();
+    });
+});
+test('teardown', s.teardown);
+
+test('setup', s.setup);
 test('insert, get by secondary index', function(t) {
     var cardboard = Cardboard(config);
 


### PR DESCRIPTION
reject features that have object properties in `cardboard.put`

/cc @willwhite @rclark 