### PR TITLE
Allow user specified ids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "0.10"
 sudo: false
-script: './node_modules/.bin/tap test/index.js'

--- a/lib/table.json
+++ b/lib/table.json
@@ -3,8 +3,7 @@
     "AttributeDefinitions": [
         {"AttributeName": "dataset", "AttributeType": "S"},
         {"AttributeName": "id", "AttributeType": "S"},
-        {"AttributeName": "cell", "AttributeType": "S"},
-        {"AttributeName": "usid", "AttributeType": "S"}
+        {"AttributeName": "cell", "AttributeType": "S"}
     ],
     "KeySchema": [
         {"AttributeName": "dataset", "KeyType": "HASH"},
@@ -20,21 +19,6 @@
             "Projection": {
                 "ProjectionType": "INCLUDE",
                 "NonKeyAttributes": [ "val", "s3url", "north", "east", "south", "west" ]
-            },
-            "ProvisionedThroughput": {
-                "ReadCapacityUnits": 5,
-                "WriteCapacityUnits": 50
-            }
-        },
-        {
-            "IndexName": "usid",
-            "KeySchema": [
-                {"AttributeName": "dataset", "KeyType": "HASH"},
-                {"AttributeName": "usid", "KeyType": "RANGE"}
-            ],
-            "Projection": {
-                "ProjectionType": "INCLUDE",
-                "NonKeyAttributes": [ "val", "s3url" ]
             },
             "ProvisionedThroughput": {
                 "ReadCapacityUnits": 5,

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "dynalite": "https://github.com/mick/dynalite/archive/queryfilters.tar.gz",
     "geojson-fixtures": "0.1.0",
     "mock-aws-s3": "^0.2.1",
-    "tap": "~0.4.9"
+    "tape": "^4.0.0"
   }
 }

--- a/test/bbox_query.js
+++ b/test/bbox_query.js
@@ -1,4 +1,4 @@
-var test = require('tap').test,
+var test = require('tape'),
     queue = require('queue-async'),
     Cardboard = require('../');
 

--- a/test/config.js
+++ b/test/config.js
@@ -1,4 +1,4 @@
-var test = require('tap').test,
+var test = require('tape'),
     fs = require('fs'),
     Cardboard = require('../'),
     _ = require('lodash'),

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,4 @@
-var test = require('tap').test,
+var test = require('tape'),
     Dynalite = require('dynalite'),
     Cardboard = require('../'),
     fakeAWS = require('mock-aws-s3'),


### PR DESCRIPTION
Fixes #111

This includes two breaking changes:
- removes the secondary index on what used to be the user-specified id (`feature.properties.id`)
- removes `cardboard.getBySecondaryId`

cc @mick @willwhite 
