### PR TITLE
createTable does not require a name, defaults to config name

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,8 +76,13 @@ module.exports = function Cardboard(config) {
     };
 
     cardboard.createTable = function(tableName, callback) {
+        if (typeof tableName === 'function') {
+            callback = tableName;
+            tableName = null;
+        }
+        
         var table = require('./lib/table.json');
-        table.TableName = tableName;
+        table.TableName = tableName || config.table;
         config.dyno.createTable(table, callback);
     };
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "buffer-equal": "0.0.1",
     "dynalite": "^0.14.0",
-    "dynamodb-test": "^0.1.2",
+    "dynamodb-test": "^0.1.3",
     "geojson-fixtures": "0.1.0",
     "geojson-random": "^0.2.2",
     "mock-aws-s3": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "buffer-equal": "0.0.1",
-    "dynalite": "https://github.com/mick/dynalite/archive/queryfilters.tar.gz",
-    "dynamodb-test": "^0.1.1",
+    "dynalite": "^0.14.0",
+    "dynamodb-test": "^0.1.2",
     "geojson-fixtures": "0.1.0",
     "geojson-random": "^0.2.2",
     "mock-aws-s3": "^0.2.1",

--- a/test/index.js
+++ b/test/index.js
@@ -3,3 +3,4 @@ require('./indexing');
 require('./bbox_query');
 require('./batch.test.js');
 require('./utils.test.js');
+require('./table.test.js');

--- a/test/setup.js
+++ b/test/setup.js
@@ -41,6 +41,17 @@ module.exports.setup = function(t, multi) {
 };
 
 module.exports.teardown = function(t) {
-    dynalite.close();
-    t.end();
+    dyno.listTables(function(err, tables) {
+        var q = queue();
+        tables.TableNames.forEach(function(table) {
+            q.defer(dyno.deleteTable, table);
+        });
+        q.awaitAll(function(err) {
+            if (err) throw err;
+            dynalite.close(function(err) {
+                if (err) throw err;
+                t.end();
+            });
+        });
+    });
 };

--- a/test/table.test.js
+++ b/test/table.test.js
@@ -1,0 +1,59 @@
+var test = require('tape');
+var _ = require('lodash');
+var dynalite = require('dynalite')({
+    createTableMs: 0,
+    updateTableMs: 0,
+    deleteTableMs: 0
+});
+
+var config = {
+    bucket: 'test',
+    prefix: 'test',
+    dyno: require('dyno')({
+        region: 'fake',
+        accessKeyId: 'fake',
+        secretAccessKey: 'fake',
+        endpoint: 'http://localhost:4567'
+    }),
+    s3: require('mock-aws-s3').S3()
+};
+
+test('[table] start dynalite', function(assert) {
+    dynalite.listen(4567, function(err) {
+        if (err) throw err;
+        assert.end();
+    });
+});
+
+test('[table] createTable - specified name', function(assert) {
+    var cardboard = require('..')(_.extend({ table: 'original' }, config));
+    cardboard.createTable(function(err) {
+        assert.ifError(err, 'success');
+
+        config.dyno.listTables(function(err, tables) {
+            if (err) throw err;
+            assert.deepEqual(tables.TableNames, ['original'], 'created table');
+            assert.end();
+        });
+    });
+});
+
+test('[table] createTable - another name', function(assert) {
+    var cardboard = require('..')(_.extend({ table: 'original' }, config));
+    cardboard.createTable('second', function(err) {
+        assert.ifError(err, 'success');
+
+        config.dyno.listTables(function(err, tables) {
+            if (err) throw err;
+            assert.deepEqual(tables.TableNames, ['original', 'second'], 'created second table');
+            assert.end();
+        });
+    });
+});
+
+test('[table] stop dynalite', function(assert) {
+    dynalite.close(function(err) {
+        if (err) throw err;
+        assert.end();
+    });
+});


### PR DESCRIPTION
Fixes #68 

Allows you to create another table, but the configured tablename is used as a default if you don't specify one.