### PR TITLE
Better control of unprocessed item response to batch requests

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -1,6 +1,8 @@
 var url = require('url');
 var queue = require('queue-async');
 var geobuf = require('geobuf');
+var _ = require('lodash');
+var Dyno = require('dyno');
 
 module.exports = function(config) {
     if (!config.bucket) throw new Error('No bucket set');
@@ -44,10 +46,23 @@ module.exports = function(config) {
         q.awaitAll(function(err) {
             if (err) return callback(err);
             config.dyno.putItems(records, function(err, items) {
+                if (err && err.unprocessed) {
+                    var table = Object.keys(err.unprocessed)[0];
+                    var unprocessed = err.unprocessed[table].map(function(item) {
+                        var id = utils.idFromRecord(item.PutRequest.Item);
+                        var i = _.findIndex(records, function(record) {
+                            return utils.idFromRecord(record) === id;
+                        });
+
+                        return geobuf.geobufToFeature(geobufs[i]);
+                    });
+
+                    err.unprocessed = { type: 'FeatureCollection', features: unprocessed };
+                }
+
                 if (err) return callback(err);
 
                 var features = geobufs.map(geobuf.geobufToFeature.bind(geobuf));
-
                 callback(null, { type: 'FeatureCollection', features: features });
             });
         });
@@ -67,6 +82,13 @@ module.exports = function(config) {
         });
 
         config.dyno.deleteItems(keys, function(err) {
+            if (err && err.unprocessed) {
+                var table = Object.keys(err.unprocessed)[0];
+                err.unprocessed = err.unprocessed[table].map(function(item) {
+                    return utils.idFromRecord(item.DeleteRequest.Key);
+                });
+            }
+
             callback(err);
         });
     };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -98,7 +98,8 @@ var Utils = module.exports = function(config) {
      * @returns {string} id - the feature's identifier
      */
     utils.idFromRecord = function(record) {
-        var bits = record.id.split('!');
+        var id = record.id.S || record.id;
+        var bits = id.split('!');
         bits.shift();
         return bits.join('!');
     };


### PR DESCRIPTION
In the event that a batch request returns unprocessed items, this PR improves cardboard's error response.

If this occurs, the `err.unprocessed` will be:
- a feature collection in the case of `cardboard.batch.put`
- an array of ids in the case of `cardboard.batch.remove`

This can be used to retry the request, if appropriate.