### PR TITLE
Bbox paging

### DIFF
--- a/bin/cardboard.js
+++ b/bin/cardboard.js
@@ -131,6 +131,7 @@ cardboard.createTable(function(err){
 
             cardboard.batch.put(aggregator.collection(), dataset, function(err) {
                 if (err) return aggregator.emit('error', err);
+                aggregator.count += aggregator.features.length;
                 aggregator.done();
             });
         };

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 var _ = require('lodash');
 var Metadata = require('./lib/metadata');
-var uniq = require('uniq');
 var queue = require('queue-async');
 var Dyno = require('dyno');
 var AWS = require('aws-sdk');
-var tilebelt = require('tilebelt');
 var geobuf = require('geobuf');
 var stream = require('stream');
 

--- a/index.js
+++ b/index.js
@@ -508,7 +508,7 @@ function Cardboard(config) {
      * @param {string} dataset - the name of the dataset
      * @param {Object} [options] - Paginiation options. If omitted, the the bbox will
      *   return the first page, limited to 100 features
-     * @param {Object} [options.limit] - Limit the number of item per page.
+     * @param {number} [options.maxFeatures] - maximum number of features to return
      * @param {Object} [options.start] - Exclusive start key to use for loading the next page. This is a feature id.
      * @param {function} callback - the callback function to handle the response
      * @example
@@ -524,7 +524,7 @@ function Cardboard(config) {
             options = {};
         }
 
-        options = _.defaults(options, { limit: 100 });
+        if (!options.maxFeatures) options.maxFeatures = 100;
 
         // List all features with a filterquery for the bounds.
         // This isnt meant to be fast, but it is meant to page by feature id.
@@ -536,7 +536,7 @@ function Cardboard(config) {
 
         var queryOptions = {
             pages: 1,
-            limit: options.limit,
+            limit: options.maxFeatures,
             filter: {
                 west: { LE: bbox[2] },
                 east: { GE: bbox[0] },
@@ -562,11 +562,11 @@ function Cardboard(config) {
                 utils.resolveFeatures(items, function(err, data) {
                     if (err) return callback(err);
                     combinedFeatures = combinedFeatures.concat(data.features);
-                    if (combinedFeatures.length >= options.limit || page >= maxPages || !meta[0].last) {
-                        data.features = combinedFeatures.slice(0, options.limit);
+                    if (combinedFeatures.length >= options.maxFeatures || page >= maxPages || !meta[0].last) {
+                        data.features = combinedFeatures.slice(0, options.maxFeatures);
                         return callback(err, data);
                     }
-                    page +=1;
+                    page += 1;
                     queryOptions.start = meta[0].last;
                     getPageOfBbox();
                 });

--- a/index.js
+++ b/index.js
@@ -526,7 +526,9 @@ function Cardboard(config) {
 
         options = _.defaults(options, { limit: 100 });
 
-        // First find features indexed in children of this tile
+        // List all features with a filterquery for the bounds.
+        // This isnt meant to be fast, but it is meant to page by feature id.
+
         var query = {
             dataset: { EQ: dataset },
             id: {BEGINS_WITH: 'id!'}

--- a/index.js
+++ b/index.js
@@ -508,6 +508,10 @@ function Cardboard(config) {
      * Find GeoJSON features that intersect a bounding box
      * @param {number[]} bbox - the bounding box as `[west, south, east, north]`
      * @param {string} dataset - the name of the dataset
+     * @param {Object} [options] - Paginiation options. If omitted, the the bbox will
+     *   return the first page, limited to 100 features
+     * @param {Object} [options.limit] - Limit the number of item per page.
+     * @param {Object} [options.start] - Exclusive start key to use for loading the next page. This is a feature id.
      * @param {function} callback - the callback function to handle the response
      * @example
      * var bbox = [-120, 30, -115, 32]; // west, south, east, north
@@ -526,7 +530,8 @@ function Cardboard(config) {
 
         // First find features indexed in children of this tile
         var query = {
-            dataset: { EQ: dataset }
+            dataset: { EQ: dataset },
+            id: {BEGINS_WITH: 'id!'}
         };
 
         var queryOptions = {
@@ -540,6 +545,13 @@ function Cardboard(config) {
             }
         };
 
+        if (options.start) {
+            queryOptions.start =  {
+                dataset: dataset,
+                id: 'id!'+options.start
+            };
+        }
+
         var maxPages = 10;
         var page = 0;
         var combinedFeatures = [];
@@ -551,7 +563,7 @@ function Cardboard(config) {
                     if (err) return callback(err);
                     combinedFeatures = combinedFeatures.concat(data.features);
                     if (combinedFeatures.length >= options.limit || page >= maxPages || !meta[0].last) {
-                        data.features = combinedFeatures.slice(0,options.limit);
+                        data.features = combinedFeatures.slice(0, options.limit);
                         return callback(err, data);
                     }
                     page +=1;

--- a/index.js
+++ b/index.js
@@ -516,129 +516,51 @@ function Cardboard(config) {
      *   collection.type === 'FeatureCollection'; // true
      * });
      */
-    cardboard.bboxQuery = function(bbox, dataset, callback) {
-        var q = queue(100);
-
-        var bboxes = [bbox];
-        var epsilon = 1E-8;
-
-        // If a query crosses the (W) antimeridian/equator, we split it
-        // into separate queries to reduce overall throughput.
-        if (bbox[0] <= -180 && bbox[2] >= -180) {
-            bboxes = bboxes.reduce(function(memo, bbox) {
-                memo.push([bbox[0], bbox[1], -180 - epsilon, bbox[3]]);
-                memo.push([-180 + epsilon, bbox[1], bbox[2], bbox[3]]);
-                return memo;
-            }, []);
-
-            if (bbox[1] <= 0 && bbox[3] >= 0) {
-                bboxes = bboxes.reduce(function(memo, bbox) {
-                    memo.push([bbox[0], bbox[1], bbox[2], -epsilon]);
-                    memo.push([bbox[0], epsilon, bbox[2], bbox[3]]);
-                    return memo;
-                }, []);
-            }
+    cardboard.bboxQuery = function(bbox, dataset, options, callback) {
+        if (typeof options === 'function') {
+            callback = options;
+            options = {};
         }
 
-        // Likewise, if a query crosses the (E) antimeridian/equator,
-        // we split it.
-        else if (bbox[0] <= 180 && bbox[2] >= 180) {
-            bboxes = bboxes.reduce(function(memo, bbox) {
-                memo.push([bbox[0], bbox[1], 180 - epsilon, bbox[3]]);
-                memo.push([180 + epsilon, bbox[1], bbox[2], bbox[3]]);
-                return memo;
-            }, []);
+        options = _.defaults(options, { limit: 100 });
 
-            if (bbox[1] <= 0 && bbox[3] >= 0) {
-                bboxes = bboxes.reduce(function(memo, bbox) {
-                    memo.push([bbox[0], bbox[1], bbox[2], -epsilon]);
-                    memo.push([bbox[0], epsilon, bbox[2], bbox[3]]);
-                    return memo;
-                }, []);
+        // First find features indexed in children of this tile
+        var query = {
+            dataset: { EQ: dataset }
+        };
+
+        var queryOptions = {
+            pages: 1,
+            limit: options.limit,
+            filter: {
+                west: { LE: bbox[2] },
+                east: { GE: bbox[0] },
+                north: { GE: bbox[1] },
+                south: { LE: bbox[3] }
             }
-        }
+        };
 
-        // If a query crosses the equator/prime meridian, we split it.
-        else if (bbox[0] <= 0 && bbox[2] >= 0) {
-            bboxes = bboxes.reduce(function(memo, bbox) {
-                memo.push([bbox[0], bbox[1], -epsilon, bbox[3]]);
-                memo.push([epsilon, bbox[1], bbox[2], bbox[3]]);
-                return memo;
-            }, []);
+        var maxPages = 10;
+        var page = 0;
+        var combinedFeatures = [];
 
-            if (bbox[1] <= 0 && bbox[3] >= 0) {
-                bboxes = bboxes.reduce(function(memo, bbox) {
-                    memo.push([bbox[0], bbox[1], bbox[2], -epsilon]);
-                    memo.push([bbox[0], epsilon, bbox[2], bbox[3]]);
-                    return memo;
-                }, []);
-            }
-        }
-
-        var tiles = bboxes.map(function(bbox) {
-            return tilebelt.bboxToTile(bbox);
-        });
-
-        // Deduplicate subquery tiles.
-        uniq(tiles, function(a, b) {
-            return !tilebelt.tilesEqual(a, b);
-        });
-
-        if (tiles.length > 1) {
-            // Filter out the z0 tile -- we'll always search it eventually.
-            tiles = _.filter(tiles, function(item) {
-                return item[2] !== 0;
-            });
-        }
-
-        tiles.forEach(function(tile) {
-            var tileKey = tilebelt.tileToQuadkey(tile);
-
-            // First find features indexed in children of this tile
-            var query = {
-                cell: { BEGINS_WITH: 'cell!' + tileKey },
-                dataset: { EQ: dataset }
-            };
-
-            var options = {
-                pages: 0,
-                index: 'cell',
-                filter: {
-                    west: { LE: bbox[2] },
-                    east: { GE: bbox[0] },
-                    north: { GE: bbox[1] },
-                    south: { LE: bbox[3] }
-                }
-            };
-            q.defer(config.dyno.query, query, options);
-
-            // Travel up the parent tiles, finding features indexed in each
-            var parentTileKey = tileKey.slice(0, -1);
-
-            while (tileKey.length > 0) {
-                query.cell = { EQ: 'cell!' + parentTileKey };
-                q.defer(config.dyno.query, query, options);
-                if (parentTileKey.length === 0) break;
-                parentTileKey = parentTileKey.slice(0, -1);
-            }
-        });
-
-        q.awaitAll(function(err, items) {
-            if (err) return callback(err);
-
-            items = _.flatten(items);
-
-            // Reduce the response's records to the set of
-            // records with unique ids.
-            uniq(items, function(a, b) {
-                return a.id !== b.id;
-            });
-
-            utils.resolveFeatures(items, function(err, data) {
+        function getPageOfBbox() {
+            config.dyno.query(query, queryOptions, function(err, items, meta) {
                 if (err) return callback(err);
-                callback(err, data);
+                utils.resolveFeatures(items, function(err, data) {
+                    if (err) return callback(err);
+                    combinedFeatures = combinedFeatures.concat(data.features);
+                    if (combinedFeatures.length >= options.limit || page >= maxPages || !meta[0].last) {
+                        data.features = combinedFeatures.slice(0,options.limit);
+                        return callback(err, data);
+                    }
+                    page +=1;
+                    queryOptions.start = meta[0].last;
+                    getPageOfBbox();
+                });
             });
-        });
+        }
+        getPageOfBbox();
     };
 
     return cardboard;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,7 +28,6 @@ function Utils(config) {
                 var val = dynamoRecord.val;
                 var uri = dynamoRecord.s3url ? url.parse(dynamoRecord.s3url) : undefined;
                 var feature;
-
                 if (val) {
                     try {
                         feature = geobuf.geobufToFeature(val);

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "queue-async": "~1.0.7",
     "sphericalmercator": "^1.0.3",
     "through2": "^2.0.0",
-    "tilebelt": "^0.5.2",
-    "uniq": "~1.0.0"
+    "tilebelt": "^0.5.2"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/test/bbox_query.js
+++ b/test/bbox_query.js
@@ -353,10 +353,10 @@ test('paging', function(t) {
     });
 
     function runQuery() {
-        cardboard.bboxQuery([0,0,2,2], dataset, {limit:2}, function(err, res) {
+        cardboard.bboxQuery([0,0,2,2], dataset, {limit:10}, function(err, res) {
             t.ifError(err, 'bbox paged query');
-            t.equal(res.features.length, 2, ' returned 2 features');
-            cardboard.bboxQuery([0,0,2,2], dataset, {limit:2, start: res.features[1].id}, function(err, res) {
+            t.equal(res.features.length, 4, ' returned 4 features');
+            cardboard.bboxQuery([0,0,2,2], dataset, {limit:10, start: res.features[1].id}, function(err, res) {
                 t.ifError(err, 'bbox paged query');
                 t.equal(res.features.length, 2, ' returned 2 features');
                 t.end();

--- a/test/bbox_query.js
+++ b/test/bbox_query.js
@@ -325,4 +325,44 @@ test('queries along antimeridian (W)', function(t) {
     }
 });
 
+test('paging', function(t) {
+    var cardboard = Cardboard(config);
+    var dataset = 'default';
+
+    // Insert 8 features
+    var features = [[1, 1], [1, 2], [2, 1], [2, 2], [-1, -1], [-1, -2], [-2, -1], [-2, -2]].map(function(coords) {
+        return {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'Point',
+                coordinates: coords
+            }
+        };
+    });
+
+    var q = queue();
+
+    features.forEach(function(f) {
+        q.defer(cardboard.put, f, dataset);
+    });
+
+    q.awaitAll(function(err) {
+        t.ifError(err, 'inserted');
+        runQuery();
+    });
+
+    function runQuery() {
+        cardboard.bboxQuery([0,0,2,2], dataset, {limit:2}, function(err, res) {
+            t.ifError(err, 'bbox paged query');
+            t.equal(res.features.length, 2, ' returned 2 features');
+            cardboard.bboxQuery([0,0,2,2], dataset, {limit:2, start: res.features[1].id}, function(err, res) {
+                t.ifError(err, 'bbox paged query');
+                t.equal(res.features.length, 2, ' returned 2 features');
+                t.end();
+            });
+        });
+    }
+});
+
 test('teardown', s.teardown);

--- a/test/bbox_query.js
+++ b/test/bbox_query.js
@@ -353,10 +353,10 @@ test('paging', function(t) {
     });
 
     function runQuery() {
-        cardboard.bboxQuery([0,0,2,2], dataset, {limit:10}, function(err, res) {
+        cardboard.bboxQuery([0,0,2,2], dataset, {maxFeatures:10}, function(err, res) {
             t.ifError(err, 'bbox paged query');
             t.equal(res.features.length, 4, ' returned 4 features');
-            cardboard.bboxQuery([0,0,2,2], dataset, {limit:10, start: res.features[1].id}, function(err, res) {
+            cardboard.bboxQuery([0,0,2,2], dataset, {maxFeatures:10, start: res.features[1].id}, function(err, res) {
                 t.ifError(err, 'bbox paged query');
                 t.equal(res.features.length, 2, ' returned 2 features');
                 t.end();


### PR DESCRIPTION
This PR feels like a step back in a way, but this enables a simple way of handing paging on bbox queries for small datasets. The next steps to make this better bbox query better involve schema changes, so lets start here for now.

This just does a list query for all features with a queryfilter.  Query filters in dynamo are applied after the data is fetch on dynamo, but before it is returned to client. So some pages will be empty, some pages will have few items, but this does allow for us to page through a bbox query using feature id.

cc @willwhite @rclark 