### PR TITLE
Geobuf length, not JSON.stringify length

### DIFF
--- a/index.js
+++ b/index.js
@@ -463,6 +463,17 @@ function Cardboard(config) {
     var metadata = {};
 
     /**
+     * Pre-flight function to request information about the size and extent of a feature
+     *
+     * @param {string} dataset - the name of the dataset
+     * @param {object} feature - a GeoJSON feature being added to the dataset
+     * @returns {object} an object describing the feature's size and extent
+     */
+    metadata.featureInfo = function(dataset, feature) {
+        return Metadata(config.dyno, dataset).getFeatureInfo(feature);
+    };
+
+    /**
      * Incrementally update a dataset's metadata with a new feature. This operation **will** create a metadata record if one does not exist.
      * @static
      * @memberof cardboard.metadata

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -4,6 +4,7 @@ var through = require('through2');
 var SphericalMercator = require('sphericalmercator');
 var merc = new SphericalMercator();
 var _ = require('lodash');
+var geobuf = require('geobuf');
 
 module.exports = Metadata;
 
@@ -55,7 +56,7 @@ function Metadata(dyno, dataset) {
     metadata.getFeatureInfo = function(feature) {
         var bounds = extent(feature);
         return {
-            size: Buffer.byteLength(JSON.stringify(feature)),
+            size: geobuf.featureToGeobuf(feature).toBuffer().length,
             bounds: bounds,
             west: bounds[0],
             south: bounds[1],

--- a/test/indexing.js
+++ b/test/indexing.js
@@ -842,3 +842,18 @@ test('Insert with and without ids specified', function(t) {
 });
 
 test('teardown', s.teardown);
+
+test('pre-flight feature info', function(t) {
+    var cardboard = Cardboard(config);
+    var haiti = _.clone(fixtures.haiti);
+    var info = cardboard.metadata.featureInfo('abc', haiti);
+    t.deepEqual(info,  {
+        size: 278,
+        bounds: [-73.388671875, 18.771115062337024, -72.1142578125, 19.80805412808859],
+        west: -73.388671875,
+        south: 18.771115062337024,
+        east: -72.1142578125,
+        north: 19.80805412808859
+    }, 'expected info');
+    t.end();
+});

--- a/test/indexing.js
+++ b/test/indexing.js
@@ -847,8 +847,8 @@ test('pre-flight feature info', function(t) {
     var cardboard = Cardboard(config);
     var haiti = _.clone(fixtures.haiti);
     var info = cardboard.metadata.featureInfo('abc', haiti);
-    t.deepEqual(info,  {
-        size: 278,
+    t.deepEqual(info, {
+        size: 106,
         bounds: [-73.388671875, 18.771115062337024, -72.1142578125, 19.80805412808859],
         west: -73.388671875,
         south: 18.771115062337024,


### PR DESCRIPTION
- Adjusts size calculations to be based on geobuf sizes instead of `JSON.stringify(feature).length`
- Adds a function to "pre-flight" a geojson feature and check its size, extent, and bounds
- Side-effect: changing the size metric impacts the suggested zoom ranges that cardboard calculates for a dataset