### PR TITLE
Handle large numeric properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var Metadata = require('./lib/metadata');
 var queue = require('queue-async');
 var Dyno = require('dyno');
 var AWS = require('aws-sdk');
-var geobuf = require('geobuf');
 var stream = require('stream');
 
 var MAX_GEOMETRY_SIZE = 1024 * 10;  // 10KB
@@ -121,7 +120,7 @@ function Cardboard(config) {
         if (encoded[1]) q.defer(config.s3.putObject.bind(config.s3), encoded[1]);
         q.defer(config.dyno.putItem, {Item: encoded[0]});
         q.await(function(err) {
-            var result = geobuf.geobufToFeature(encoded[0].val || encoded[1].Body);
+            var result = utils.decode(encoded[0].val || encoded[1].Body);
             result.id = utils.idFromRecord(encoded[0]);
             callback(err, result);
         });

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -1,6 +1,4 @@
 var queue = require('queue-async');
-var geobuf = require('geobuf');
-var _ = require('lodash');
 var Dyno = require('dyno');
 var AWS = require('aws-sdk');
 
@@ -57,24 +55,20 @@ module.exports = function(config) {
             config.dyno.batchWriteItemRequests(params).sendAll(10, function(err, res, unprocessed) {
                 if (err) return callback(err);
 
-                if (!unprocessed) {
-                    var features = geobufs.map(geobuf.geobufToFeature.bind(geobuf));
-                    return callback(null, { type: 'FeatureCollection', features: features });
-                }
+                if (!unprocessed)
+                    return utils.resolveFeatures(records, callback);
 
-                var collection = unprocessed.reduce(function(collection, req) {
+                var features = unprocessed.reduce(function(features, req) {
                     req.params.RequestItems[table].forEach(function(item) {
-                        var id = utils.idFromRecord(item.PutRequest.Item);
-                        var i = _.findIndex(records, function(record) {
-                            return utils.idFromRecord(record) === id;
-                        });
-
-                        collection.features.push(geobuf.geobufToFeature(geobufs[i]));
+                        features.push(item.PutRequest.Item);
                     });
-                    return collection;
-                }, { type: 'FeatureCollection', features: [] });
+                    return features;
+                }, []);
 
-                callback({ unprocessed: collection });
+                utils.resolveFeatures(features, function(err, collection) {
+                    if (err) return callback(err);
+                    callback({ unprocessed: collection });
+                });
             });
         });
     };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,6 +9,18 @@ var tilebelt = require('tilebelt');
 
 module.exports = Utils;
 
+function decode(buf, callback) {
+    var feature;
+    try {
+        feature = geobuf.geobufToFeature(buf);
+    } catch(err) {
+        return callback(err);
+    }
+
+    for (var key in feature.properties) feature.properties[key] = JSON.parse(feature.properties[key]);
+    callback(null, feature);
+}
+
 function Utils(config) {
     /**
      * A module containing internal utility functions
@@ -27,15 +39,8 @@ function Utils(config) {
             q.defer(function(next) {
                 var val = dynamoRecord.val;
                 var uri = dynamoRecord.s3url ? url.parse(dynamoRecord.s3url) : undefined;
-                var feature;
-                if (val) {
-                    try {
-                        feature = geobuf.geobufToFeature(val);
-                    } catch(e) {
-                        return next(e);
-                    }
-                    return next(null, feature);
-                }
+
+                if (val) return decode(val, next);
                 if (!uri) return next(new Error('No feature data was found for ' + utils.idFromRecord(dynamoRecord)));
 
                 config.s3.getObject({
@@ -43,12 +48,7 @@ function Utils(config) {
                     Key: uri.pathname.substr(1)
                 }, function(err, data) {
                     if (err) return next(err);
-                    try {
-                        feature = geobuf.geobufToFeature(data.Body);
-                    } catch(e) {
-                        return next(e);
-                    }
-                    next(null, feature);
+                    decode(data.Body, next);
                 });
             });
         });
@@ -83,6 +83,11 @@ function Utils(config) {
             throw new Error('Unlocated features can not be stored.');
 
         var info = Metadata(config.dyno, dataset).getFeatureInfo(f);
+
+        var encodedProperties = {};
+        for (var key in f.properties) encodedProperties[key] = JSON.stringify(f.properties[key]);
+        f.properties = encodedProperties;
+
         var buf = geobuf.featureToGeobuf(f).toBuffer();
         var tile = tilebelt.bboxToTile([info.west, info.south, info.east, info.north]);
         var cell = tilebelt.tileToQuadkey(tile);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,23 +9,25 @@ var tilebelt = require('tilebelt');
 
 module.exports = Utils;
 
-function decode(buf, callback) {
-    var feature;
-    try {
-        feature = geobuf.geobufToFeature(buf);
-    } catch(err) {
-        return callback(err);
-    }
-
-    for (var key in feature.properties) feature.properties[key] = JSON.parse(feature.properties[key]);
-    callback(null, feature);
-}
-
 function Utils(config) {
     /**
      * A module containing internal utility functions
      */
     var utils = {};
+
+    utils.decode = function(buf, callback) {
+        var feature;
+        try {
+            feature = geobuf.geobufToFeature(buf);
+        } catch (err) {
+            if (callback) return callback(err);
+            else throw err;
+        }
+
+        for (var key in feature.properties) feature.properties[key] = JSON.parse(feature.properties[key]);
+        if (callback) callback(null, feature);
+        else return feature;
+    };
 
     /**
      * Convert a set of backend records into a GeoJSON features
@@ -40,7 +42,7 @@ function Utils(config) {
                 var val = dynamoRecord.val;
                 var uri = dynamoRecord.s3url ? url.parse(dynamoRecord.s3url) : undefined;
 
-                if (val) return decode(val, next);
+                if (val) return utils.decode(val, next);
                 if (!uri) return next(new Error('No feature data was found for ' + utils.idFromRecord(dynamoRecord)));
 
                 config.s3.getObject({
@@ -48,7 +50,7 @@ function Utils(config) {
                     Key: uri.pathname.substr(1)
                 }, function(err, data) {
                     if (err) return next(err);
-                    decode(data.Body, next);
+                    utils.decode(data.Body, next);
                 });
             });
         });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,7 +24,11 @@ function Utils(config) {
             else throw err;
         }
 
-        for (var key in feature.properties) feature.properties[key] = JSON.parse(feature.properties[key]);
+        for (var key in feature.properties) {
+            try { feature.properties[key] = JSON.parse(feature.properties[key]); }
+            catch (err) { /* no-op */ }
+        }
+
         if (callback) callback(null, feature);
         else return feature;
     };

--- a/test/data/numeric-properties.geojson
+++ b/test/data/numeric-properties.geojson
@@ -1,0 +1,26 @@
+{
+  "type": "Feature",
+  "properties": {
+    "@uid": 3029661,
+    "tiger:cfcc": "A63",
+    "@id": 17305827,
+    "@timestamp": 1461579648,
+    "destination": "Yarbrough Drive; Sumac Drive",
+    "tiger:reviewed": "no",
+    "@changeset": 38852794,
+    "tiger:county": "El Paso, TX",
+    "@user": "saikabhi",
+    "oneway": "yes",
+    "@version": 7,
+    "@type": "way",
+    "highway": "motorway_link"
+  },
+  "geometry": {
+    "coordinates": [
+      [-106.348721, 31.754626],
+      [-106.347656, 31.753794]
+    ],
+    "type": "LineString"
+  },
+  "id": "1"
+}

--- a/test/geobuf-conversion.test.js
+++ b/test/geobuf-conversion.test.js
@@ -1,0 +1,15 @@
+var test = require('tape');
+var path = require('path');
+var fs = require('fs');
+// var utils = require('../lib/utils');
+var geobuf = require('geobuf');
+
+test('[geobuf conversion] does not affect numeric properties', function(assert) {
+    var fixture = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'data', 'numeric-properties.geojson')));
+
+    var buf = geobuf.featureToGeobuf(fixture).toBuffer();
+    var roundtrip = geobuf.geobufToFeature(buf);
+
+    assert.deepEqual(roundtrip.properties, fixture.properties, 'feature properties unaffected');
+    assert.end();
+});

--- a/test/geobuf-conversion.test.js
+++ b/test/geobuf-conversion.test.js
@@ -1,15 +1,33 @@
 var test = require('tape');
 var path = require('path');
 var fs = require('fs');
-// var utils = require('../lib/utils');
+var utils = require('../lib/utils');
 var geobuf = require('geobuf');
+var fixture = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'data', 'numeric-properties.geojson')));
 
-test('[geobuf conversion] does not affect numeric properties', function(assert) {
-    var fixture = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'data', 'numeric-properties.geojson')));
-
+test('[geobuf conversion] geobuf round-trip changes numeric properties', function(assert) {
     var buf = geobuf.featureToGeobuf(fixture).toBuffer();
     var roundtrip = geobuf.geobufToFeature(buf);
 
-    assert.deepEqual(roundtrip.properties, fixture.properties, 'feature properties unaffected');
+    assert.notEqual(
+        roundtrip.properties['@changeset'],
+        fixture.properties['@changeset'],
+        'large numeric feature properties are adjusted by straight geobuf conversion'
+    );
     assert.end();
+});
+
+test('[geobuf conversion] cardboard round-trip does not change numeric properties', function(assert) {
+    var config = { MAX_GEOMETRY_SIZE: 99999999 };
+    var record = utils(config).toDatabaseRecord(fixture, 'dataset')[0];
+    utils(config).resolveFeatures([record], function(err, collection) {
+        if (err) return assert.end(err);
+        var roundtrip = collection.features[0];
+        assert.equal(
+            roundtrip.properties['@changeset'],
+            fixture.properties['@changeset'],
+            'large numeric feature properties are not adjusted by cardboard roundtrip'
+        );
+        assert.end();
+    });
 });

--- a/test/indexing.test.js
+++ b/test/indexing.test.js
@@ -510,13 +510,13 @@ test('setup', s.setup);
 
 test('list all pages', function(t) {
     var cardboard = Cardboard(config);
+    var collection = featureCollection([
+        _.clone(fixtures.haiti),
+        _.clone(fixtures.haiti),
+        _.clone(fixtures.haiti)
+    ]);
 
-    cardboard.batch.put(
-        featureCollection([
-            _.clone(fixtures.haiti),
-            _.clone(fixtures.haiti),
-            _.clone(fixtures.haiti)
-        ]), 'default', page);
+    cardboard.batch.put(collection, 'default', page);
 
     function page(err, putResults) {
         t.equal(err, null);
@@ -534,9 +534,12 @@ test('list all pages', function(t) {
                         memo = memo.concat(page);
                         return memo;
                     }, []);
+
                     t.equal(pages.length, 3);
                     t.equal(items.length, 3);
+
                     t.deepEqual(items, putResults.features);
+
                     t.end();
                     return;
                 }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,6 +5,7 @@ var path = require('path');
 var _ = require('lodash');
 var fixtures = require('./fixtures');
 var url = require('url');
+var geobuf = require('geobuf');
 
 var states = fs.readFileSync(path.resolve(__dirname, 'data', 'states.geojson'), 'utf8');
 states = JSON.parse(states);
@@ -360,6 +361,28 @@ test('[utils] idFromRecord - has ! in the id', function(assert) {
 test('[utils] idFromRecord - emoji', function(assert) {
     var record = { id: 'id!\u1F471' };
     assert.equal(utils.idFromRecord(record), '\u1F471', 'expected value');
+    assert.end();
+});
+
+test('[utils] decode - does not fail on non-stringified properties', function(assert) {
+    var feature = {
+        type: 'Feature',
+        properties: {
+            str: 'a string',
+            obj: { an: 'object' },
+            arr: ['an', 'array'],
+            num: 12,
+            bool: true
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+        }
+    };
+
+    var buf = geobuf.featureToGeobuf(feature).toBuffer();
+    var output = utils.decode(buf);
+    assert.deepEqual(output.properties, feature.properties, 'reads non-stringified properties');
     assert.end();
 });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -3,7 +3,6 @@ var dynamodb = require('dynamodb-test')(test, 'cardboard', require('../lib/table
 var fs = require('fs');
 var path = require('path');
 var _ = require('lodash');
-var geobuf = require('geobuf');
 var fixtures = require('./fixtures');
 var url = require('url');
 
@@ -135,7 +134,7 @@ test('[utils] toDatabaseRecord - no ID', function(assert) {
     assert.ok(item.val, 'geobuf was stored in the item');
 
     noId.id = utils.idFromRecord(item);
-    assert.deepEqual(geobuf.geobufToFeature(item.val), noId, 'geobuf encoded as expected');
+    assert.deepEqual(utils.decode(item.val), noId, 'geobuf encoded as expected');
 
     assert.end();
 });
@@ -171,7 +170,7 @@ test('[utils] toDatabaseRecord - large feature', function(assert) {
     assert.ok(item.s3url.indexOf('s3://test/test/dataset/' + utils.idFromRecord(item)) === 0, 's3url was assigned correctly');
 
     noId.id = utils.idFromRecord(item);
-    assert.deepEqual(geobuf.geobufToFeature(s3params.Body), noId, 'geobuf encoded as expected');
+    assert.deepEqual(utils.decode(s3params.Body), noId, 'geobuf encoded as expected');
     assert.equal(s3params.Bucket, config.bucket, 'S3 params include proper bucket');
     assert.equal(s3params.Key, item.s3url.split('s3://test/')[1], 'S3 params include proper key');
 
@@ -206,7 +205,7 @@ test('[utils] toDatabaseRecord - with ID', function(assert) {
     assert.equal(item.cell, 'cell!3000000000000000000000000000', 'expected cell');
     assert.notOk(item.s3url, 's3url was not assigned to a small feature');
     assert.ok(item.val, 'geobuf was stored in the item');
-    assert.deepEqual(geobuf.geobufToFeature(item.val), hasId, 'geobuf encoded as expected');
+    assert.deepEqual(utils.decode(item.val), hasId, 'geobuf encoded as expected');
 
     assert.end();
 });
@@ -241,7 +240,7 @@ test('[utils] toDatabaseRecord - numeric IDs become strings', function(assert) {
     assert.ok(item.val, 'geobuf was stored in the item');
 
     numericId.id = numericId.id.toString();
-    assert.deepEqual(geobuf.geobufToFeature(item.val), numericId, 'geobuf encoded as expected');
+    assert.deepEqual(utils.decode(item.val), numericId, 'geobuf encoded as expected');
 
     assert.end();
 });
@@ -276,7 +275,7 @@ test('[utils] toDatabaseRecord - zero is an acceptable ID', function(assert) {
     assert.ok(item.val, 'geobuf was stored in the item');
 
     zeroId.id = utils.idFromRecord(item);
-    assert.deepEqual(geobuf.geobufToFeature(item.val), zeroId, 'geobuf encoded as expected');
+    assert.deepEqual(utils.decode(item.val), zeroId, 'geobuf encoded as expected');
 
     assert.end();
 });
@@ -312,7 +311,7 @@ test('[utils] toDatabaseRecord - null ID', function(assert) {
     assert.ok(item.val, 'geobuf was stored in the item');
 
     nullId.id = utils.idFromRecord(item);
-    assert.deepEqual(geobuf.geobufToFeature(item.val), nullId, 'geobuf encoded as expected');
+    assert.deepEqual(utils.decode(item.val), nullId, 'geobuf encoded as expected');
 
     assert.end();
 });


### PR DESCRIPTION
The old version of geobuf in use in cardboard will lose precision on large numeric properties. This PR circumvents the issue by encoding all properties as strings, and parsing them back on when read from the geobuf.

Remaining test failures are due to bad payloads returned from batch API requests. Will tackle this as soon as I can.

cc @batpad @mcwhittemore 