### PR TITLE
geobuf with double-encoded properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "aws-sdk": "~2.1.5",
     "cuid": "1.2.4",
     "dyno": "^1.0.1",
-    "geobuf": "0.2.4",
+    "geobuf": "https://github.com/mapbox/geobuf/tarball/double",
     "geojson-extent": "^0.1.0",
     "geojson-normalize": "0.0.0",
     "lodash": "~2.4.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "aws-sdk": "~2.1.5",
     "cuid": "1.2.4",
     "dyno": "^1.0.1",
-    "geobuf": "https://github.com/mapbox/geobuf/tarball/double",
+    "geobuf": "0.2.5",
     "geojson-extent": "^0.1.0",
     "geojson-normalize": "0.0.0",
     "lodash": "~2.4.1",

--- a/test/data/numeric-properties.geojson
+++ b/test/data/numeric-properties.geojson
@@ -1,0 +1,26 @@
+{
+  "type": "Feature",
+  "properties": {
+    "@uid": 3029661,
+    "tiger:cfcc": "A63",
+    "@id": 17305827,
+    "@timestamp": 1461579648,
+    "destination": "Yarbrough Drive; Sumac Drive",
+    "tiger:reviewed": "no",
+    "@changeset": 38852794,
+    "tiger:county": "El Paso, TX",
+    "@user": "saikabhi",
+    "oneway": "yes",
+    "@version": 7,
+    "@type": "way",
+    "highway": "motorway_link"
+  },
+  "geometry": {
+    "coordinates": [
+      [-106.348721, 31.754626],
+      [-106.347656, 31.753794]
+    ],
+    "type": "LineString"
+  },
+  "id": "1"
+}

--- a/test/geobuf-conversion.test.js
+++ b/test/geobuf-conversion.test.js
@@ -1,0 +1,20 @@
+var test = require('tape');
+var path = require('path');
+var fs = require('fs');
+var utils = require('../lib/utils');
+var fixture = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'data', 'numeric-properties.geojson')));
+
+test('[geobuf conversion] cardboard round-trip does not change numeric properties', function(assert) {
+    var config = { MAX_GEOMETRY_SIZE: 99999999 };
+    var record = utils(config).toDatabaseRecord(fixture, 'dataset')[0];
+    utils(config).resolveFeatures([record], function(err, collection) {
+        if (err) return assert.end(err);
+        var roundtrip = collection.features[0];
+        assert.equal(
+            roundtrip.properties['@changeset'],
+            fixture.properties['@changeset'],
+            'large numeric feature properties are not adjusted by cardboard roundtrip'
+        );
+        assert.end();
+    });
+});


### PR DESCRIPTION
This is a better alternative to #168 because it is actually a non-breaking change.

cc @mcwhittemore 