### PR TITLE
Proposed quadkey index for more efficient bbox query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+npm-debug.log
+node_modules
 test/test
 coverage/
 .nyc_output/

--- a/index.js
+++ b/index.js
@@ -123,6 +123,7 @@ function Cardboard(config) {
         q.await(function(err) {
             var result = geobuf.geobufToFeature(encoded[0].val || encoded[1].Body);
             result.id = utils.idFromRecord(encoded[0]);
+            result.quadkey = encoded[0].quadkey;
             callback(err, result);
         });
     };
@@ -597,6 +598,82 @@ function Cardboard(config) {
                     params.ExclusiveStartKey = {
                         dataset: dataset, id: items.slice(-1)[0].id
                     };
+                    getPageOfBbox();
+                });
+            });
+        }
+        getPageOfBbox();
+    };
+
+    /**
+     * Find GeoJSON features that intersect a bounding box using Quadkey Index
+     * @param {number[]} bbox - the bounding box as `[west, south, east, north]`
+     * @param {string} dataset - the name of the dataset
+     * @param {Object} [options] - Paginiation options. If omitted, the the bbox will
+     *   return the first page, limited to 100 features
+     * @param {number} [options.maxFeatures] - maximum number of features to return
+     * @param {Object} [options.start] - Exclusive start key to use for loading the next page. This is quadkey and feature id.
+     * @param {function} callback - the callback function to handle the response
+     * @example
+     * var bbox = [-120, 30, -115, 32]; // west, south, east, north
+     * carboard.bboxQuadkeyQuery(bbox, 'my-dataset', function(err, collection) {
+     *   if (err) throw err;
+     *   collection.type === 'FeatureCollection'; // true
+     * });
+     */
+    cardboard.bboxQuadkeyQuery = function(bbox, dataset, options, callback) {
+        if (typeof options === 'function') {
+            callback = options;
+            options = {};
+        }
+
+        if (!options.maxFeatures) options.maxFeatures = 100;
+
+        // List all features with a filterquery for the bounds.
+        // This isnt meant to be fast, but it is meant to page by feature id.
+
+        var quadkeyRange = utils.calcQuadkeyRange(bbox);
+
+        var params = {
+            IndexName: 'quadkey',
+            ExpressionAttributeNames: { '#quadkey': 'quadkey', '#dataset': 'dataset' },
+            ExpressionAttributeValues: {
+                ':nw': quadkeyRange.nw,
+                ':se': quadkeyRange.se,
+                ':dataset': dataset,
+                ':west': bbox[2],
+                ':east': bbox[0],
+                ':north': bbox[1],
+                ':south': bbox[3]
+            },
+            KeyConditionExpression: '#dataset = :dataset and #quadkey BETWEEN :nw and :se',
+            Limit: options.maxFeatures,
+            FilterExpression: 'west <= :west and east >= :east and north >= :north and south <= :south'
+        };
+
+        if (options.start) params.ExclusiveStartKey = {
+            dataset: dataset, quadkey: options.start.quadkey, id: options.start.id
+        };
+
+        var maxPages = 10;
+        var page = 0;
+        var combinedFeatures = [];
+
+        function getPageOfBbox() {
+            config.dyno.query(params, function(err, res) {
+                if (err) return callback(err);
+
+                var items = res.Items;
+                utils.resolveFeatures(items, function(err, data) {
+                    if (err) return callback(err);
+
+                    combinedFeatures = combinedFeatures.concat(data.features);
+                    if (res.ScannedCount <= options.maxFeatures || combinedFeatures.length >= options.maxFeatures || page >= maxPages || !items.length) {
+                        data.features = combinedFeatures.slice(0, options.maxFeatures);
+                        return callback(err, data);
+                    }
+                    page += 1;
+                    params.ExclusiveStartKey = res.LastEvaluatedKey;
                     getPageOfBbox();
                 });
             });

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -58,7 +58,13 @@ module.exports = function(config) {
                 if (err) return callback(err);
 
                 if (!unprocessed) {
-                    var features = geobufs.map(geobuf.geobufToFeature.bind(geobuf));
+                    var features = geobufs.map(function(buf) {
+                        var feature = geobuf.geobufToFeature(buf);
+                        var idx = _.findIndex(records, { id: 'id!' + feature.id });
+                        feature['quadkey'] = records[idx].quadkey;
+                        return feature;
+                    });
+
                     return callback(null, { type: 'FeatureCollection', features: features });
                 }
 

--- a/lib/table.json
+++ b/lib/table.json
@@ -3,7 +3,8 @@
     "AttributeDefinitions": [
         {"AttributeName": "dataset", "AttributeType": "S"},
         {"AttributeName": "id", "AttributeType": "S"},
-        {"AttributeName": "cell", "AttributeType": "S"}
+        {"AttributeName": "cell", "AttributeType": "S"},
+        {"AttributeName": "quadkey", "AttributeType": "S"}
     ],
     "KeySchema": [
         {"AttributeName": "dataset", "KeyType": "HASH"},
@@ -23,6 +24,19 @@
             "ProvisionedThroughput": {
                 "ReadCapacityUnits": 5,
                 "WriteCapacityUnits": 50
+            }
+        }
+    ],
+    "LocalSecondaryIndexes": [
+        {
+            "IndexName": "quadkey",
+            "KeySchema": [
+                {"AttributeName": "dataset", "KeyType": "HASH"},
+                {"AttributeName": "quadkey", "KeyType": "RANGE"}
+            ],
+            "Projection": {
+                "ProjectionType": "INCLUDE",
+                "NonKeyAttributes": [ "val", "s3url", "north", "east", "south", "west" ]
             }
         }
     ],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,6 +31,7 @@ function Utils(config) {
                 if (val) {
                     try {
                         feature = geobuf.geobufToFeature(val);
+                        feature.quadkey = dynamoRecord.quadkey;
                     } catch(e) {
                         return next(e);
                     }
@@ -45,6 +46,7 @@ function Utils(config) {
                     if (err) return next(err);
                     try {
                         feature = geobuf.geobufToFeature(data.Body);
+                        feature.quadkey = dynamoRecord.quadkey;
                     } catch(e) {
                         return next(e);
                     }
@@ -83,9 +85,12 @@ function Utils(config) {
             throw new Error('Unlocated features can not be stored.');
 
         var info = Metadata(config.dyno, dataset).getFeatureInfo(f);
+        var bbox = [info.west, info.south, info.east, info.north];
         var buf = geobuf.featureToGeobuf(f).toBuffer();
-        var tile = tilebelt.bboxToTile([info.west, info.south, info.east, info.north]);
+        var tile = tilebelt.bboxToTile(bbox);
         var cell = tilebelt.tileToQuadkey(tile);
+        var centerpoint = utils.getCenterpoint(bbox);
+        var quadkey = utils.getQuadkey(centerpoint[0], centerpoint[1]);
         var useS3 = buf.length >= config.MAX_GEOMETRY_SIZE;
         var s3Key = [config.prefix, dataset, primary, +new Date()].join('/');
         var s3Params = { Bucket: config.bucket, Key: s3Key, Body: buf };
@@ -94,6 +99,7 @@ function Utils(config) {
             dataset: dataset,
             id: 'id!' + primary,
             cell: 'cell!' + cell,
+            quadkey: quadkey,
             size: info.size,
             west: truncateNum(info.west),
             south: truncateNum(info.south),
@@ -121,6 +127,79 @@ function Utils(config) {
         bits.shift();
         return bits.join('!');
     };
+
+
+    /**
+    * Gets bbox centerpoint
+    * @param {number[]} bbox - feature bounding box
+    * @returns {number[]} centerpoint - [lon, lat]
+    */
+    utils.getCenterpoint = function(bbox) {
+        var b = bbox.map(truncateNum);
+        var lon = (b[0] + b[2])/2;
+        var lat = (b[1] + b[3])/2;
+        return [lon, lat];
+    }
+
+    /**
+    * Gets quadkey from point
+    * @param {number} lon - longitude
+    * @param {number} lat - latitude
+    * @param {number} [zoom=25] - default zoom 25 equals ~1m square tile
+    * @returns {number} quadkey - tile quadkey
+    */
+    utils.getQuadkey = function(lon, lat) {
+        var z = 25;
+        var tile = tilebelt.pointToTile(truncateNum(lon), truncateNum(lat), z);
+        return tilebelt.tileToQuadkey(tile);
+    }
+
+    /**
+    * Calculate quadkey range based on the bbox. To mitigate possible missing features along bbox edges,
+    * the quadkey range will be computed at 200% the bbox.
+    * @private
+    * @params {number[]} bbox - the bounding box as [west, south, east, north]
+    * @returns {QuadkeyRange} - the calculated quadkey range
+    *
+    * @typedef QuadkeyRange
+    * @type Object
+    * @property {string} nw - the northwest corner quadkey
+    * @property {string} se - the southeast corner quadkey
+    */
+    utils.calcQuadkeyRange = function(bbox) {
+        function normalizeMeridian(val, bounding) {
+            var deg = truncateNum(val);
+            if (deg < -bounding) return (deg + bounding) + bounding;
+            if (deg > bounding) return (deg - bounding) - bounding;
+            return deg;
+        }
+
+        function doubleAxis(a, b, bounding) {
+            var high = Math.max(a, b);
+            var low = Math.min(a, b);
+            var center = (high + low)/2;
+            var multiplied = (high - low);
+            var max = center + multiplied;
+            var min = center - multiplied;
+
+            return {
+                max: max >= bounding ? bounding - 0.0001 : max,
+                min: min <= -bounding ? -bounding + 0.0001 : min
+            };
+        }
+
+        var west = normalizeMeridian(bbox[0], 180);
+        var east = normalizeMeridian(bbox[2], 180);
+        var south = normalizeMeridian(bbox[1], 90);
+        var north = normalizeMeridian(bbox[3], 90);
+        var horizontal = doubleAxis(east, west, 180);
+        var vertical = doubleAxis(north, south, 90);
+
+        var nw = utils.getQuadkey(horizontal.min, vertical.max);
+        var se = utils.getQuadkey(horizontal.max, vertical.min);
+
+        return {nw: nw, se: se};
+    }
 
     return utils;
 }

--- a/test/bbox_quadkey_query.test.js
+++ b/test/bbox_quadkey_query.test.js
@@ -1,0 +1,369 @@
+var test = require('tape');
+var queue = require('queue-async');
+var Cardboard = require('../');
+
+var s = require('./setup');
+var config = s.config;
+
+test('setup', s.setup);
+
+test('queries along 0 lat/lon', function(t) {
+    var cardboard = Cardboard(config);
+    var dataset = 'default';
+
+    // Insert one feature per quadrant
+    var features = [[-1, 1], [1, 1], [1, -1], [-1, -1]].map(function(coords) {
+        return {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'Point',
+                coordinates: coords
+            }
+        };
+    });
+
+    // Query in each quadrant + queries that just cross quadrant bounds
+    // all queries should return a single result
+    var queries = [
+        [-10, 0, 0, 10],
+        [-10, -0.5, 0.5, 10],
+        [0, 0, 10, 10],
+        [-0.5, -0.5, 10, 10],
+        [0, -10, 10, 0],
+        [-0.5, -10, 10, 0.5],
+        [-10, -10, 0, 0],
+        [-10, -10, 0.5, 0.5]
+    ];
+
+    var q = queue();
+
+    features.forEach(function(f) {
+        q.defer(cardboard.put, f, dataset);
+    });
+
+    q.awaitAll(function(err) {
+        t.ifError(err, 'inserted');
+        runQueries();
+    });
+
+    function runQueries() {
+        var q = queue();
+
+        queries.forEach(function(query) {
+            function deal(callback) {
+                cardboard.bboxQuadkeyQuery(query, dataset, function(err, res) {
+                    if (err) return callback(err);
+                    t.equal(res.features.length, 1, query.join(',') + ' returned one feature');
+                    callback();
+                });
+            }
+
+            q.defer(deal);
+        });
+
+        q.await(function(err) {
+            t.ifError(err, 'passed queries');
+            t.end();
+        });
+    }
+});
+
+test('teardown', s.teardown);
+
+// Test findability of a linestring crossing the prime meridian west to east
+// N of the equator.
+//
+// There's a query on either side of lon 0 and two meridian-spanning
+// queries.
+test('setup', s.setup);
+
+test('query for line crossing 0 lon n of eq', function(t) {
+    var cardboard = Cardboard(config);
+    var dataset = 'line-query';
+
+    var feature = {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+            type: 'LineString',
+            coordinates: [[-1, 1], [1, 1]]
+        }};
+
+    // all queries should return a single result
+    var queries = [
+        [-10, 0, 0, 10],
+        [-0.75, 0.75, -0.25, 1.25],
+        [-10, -0.5, 0.5, 10],
+        [0, 0, 10, 10],
+        [0.25, 0.75, 0.75, 1.25],
+        [-0.5, -0.5, 10, 10],
+        [-1E-6, 1 - 1E-6, 1E+6, 1 + 1E+6],
+        [-180, -85.05112877980659, 0, 85.0511287798066],
+        [-180, -85.05112877980659, 1, 85.0511287798066]
+    ];
+
+    var q = queue();
+    q.defer(cardboard.put, feature, dataset);
+    q.awaitAll(function(err) {
+        t.ifError(err, 'inserted');
+        runQueries();
+    });
+
+    function runQueries() {
+        var q = queue();
+
+        queries.forEach(function(query) {
+            function deal(callback) {
+                cardboard.bboxQuadkeyQuery(query, dataset, function(err, res) {
+                    if (err) return callback(err);
+                    t.equal(res.features.length, 1, query.join(',') + ' returned one feature');
+                    callback();
+                });
+            }
+
+            q.defer(deal);
+        });
+
+        q.await(function(err) {
+            t.ifError(err, 'passed queries');
+            t.end();
+        });
+    }
+});
+
+test('teardown', s.teardown);
+
+// Test findability of a linestring crossing the prime meridian west to east
+// S of the equator.
+//
+// There's a query on either side of lon 0 and two meridian-spanning
+// queries.
+test('setup', s.setup);
+
+test('query for line crossing 0 lon s of eq', function(t) {
+    var cardboard = Cardboard(config);
+    var dataset = 'line-query';
+
+    var feature = {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+            type: 'LineString',
+            coordinates: [[-1, -1], [1, -1]]
+        }};
+
+    // all queries should return a single result
+    var queries = [
+        [-10, -10, 0, 0],
+        [-0.75, -1.25, -0.25, -0.75],
+        [-10, -9.5, 0.5, 0.5],
+        [0, -10, 10, 0],
+        [0.25, -1.25, 0.75, -0.75],
+        [-0.5, -9.5, 10, 10],
+        [-1E-6, -1 - 1E-6, 1E+6, -1 + 1E+6],
+        [-180, -85.05112877980659, 0, 85.0511287798066],
+        [-180, -85.05112877980659, 1, 85.0511287798066]
+    ];
+
+    var q = queue();
+    q.defer(cardboard.put, feature, dataset);
+    q.awaitAll(function(err) {
+        t.ifError(err, 'inserted');
+        runQueries();
+    });
+
+    function runQueries() {
+        var q = queue();
+
+        queries.forEach(function(query) {
+            function deal(callback) {
+                cardboard.bboxQuadkeyQuery(query, dataset, function(err, res) {
+                    if (err) return callback(err);
+                    t.equal(res.features.length, 1, query.join(',') + ' returned one feature');
+                    callback();
+                });
+            }
+
+            q.defer(deal);
+        });
+
+        q.await(function(err) {
+            t.ifError(err, 'passed queries');
+            t.end();
+        });
+    }
+});
+
+test('teardown', s.teardown);
+
+// Test findability of a linestring near 90dW N of the equator.
+test('setup', s.setup);
+
+test('query for line near -90 lon n of eq', function(t) {
+    var cardboard = Cardboard(config);
+    var dataset = 'line-query';
+
+    // tile for this feature: [ 31, 63, 7 ]
+    var wanted = {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+            type: 'LineString',
+            coordinates: [[-92, 1], [-91, 1]]
+        }};
+
+    // tile for this feature: [0, 0, 0]
+    var unwanted = {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+            type: 'LineString',
+            coordinates: [[-1, 1], [1, 1]]
+        }};
+
+    // all queries should return a single result
+    var queries = [
+        [-93, 0, -90, 2],           // [0, 0, 0] -- right answer only because
+                                    // of query filters.
+        [-92.5, 0.5, -90.5, 1.5]    // [ 31, 63, 7 ]
+    ];
+
+    var q = queue();
+    q.defer(cardboard.put, wanted, dataset);
+    q.defer(cardboard.put, unwanted, dataset);
+    q.awaitAll(function(err) {
+        t.ifError(err, 'inserted');
+        runQueries();
+    });
+
+    function runQueries() {
+        var q = queue();
+
+        queries.forEach(function(query) {
+            function deal(callback) {
+                cardboard.bboxQuadkeyQuery(query, dataset, function(err, res) {
+                    if (err) return callback(err);
+                    t.equal(res.features.length, 1, query.join(',') + ' returned one feature');
+                    callback();
+                });
+            }
+
+            q.defer(deal);
+        });
+
+        q.await(function(err) {
+            t.ifError(err, 'passed queries');
+            t.end();
+        });
+    }
+});
+
+test('teardown', s.teardown);
+
+test('setup', s.setup);
+
+test('queries along antimeridian (W)', function(t) {
+    var cardboard = Cardboard(config);
+    var dataset = 'default';
+
+    // Insert one feature per quadrant
+    var features = [[-181, 1], [-179, 1], [-179, -1], [-181, -1]].map(function(coords) {
+        return {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'Point',
+                coordinates: coords
+            }
+        };
+    });
+
+    // Query in each quadrant + queries that just cross quadrant bounds
+    // all queries should return a single result
+    var queries = [
+        [-190, 0, -180, 10],
+        [-190, -0.5, -179.5, 10],
+        [-180, 0, -170, 10],
+        [-180.5, -0.5, -170, 10],
+        [-180, -10, -170, 0],
+        [-180.5, -10, -170, 0.5],
+        [-190, -10, -180, 0],
+        [-190, -10, -179.5, 0.5]
+    ];
+
+    var q = queue();
+
+    features.forEach(function(f) {
+        q.defer(cardboard.put, f, dataset);
+    });
+
+    q.awaitAll(function(err) {
+        t.ifError(err, 'inserted');
+        runQueries();
+    });
+
+    function runQueries() {
+        var q = queue();
+
+        queries.forEach(function(query) {
+            function deal(callback) {
+                cardboard.bboxQuadkeyQuery(query, dataset, function(err, res) {
+                    if (err) return callback(err);
+                    t.equal(res.features.length, 1, query.join(',') + ' returned one feature');
+                    callback();
+                });
+            }
+
+            q.defer(deal);
+        });
+
+        q.await(function(err) {
+            t.ifError(err, 'passed queries');
+            t.end();
+        });
+    }
+});
+
+test('paging by quadkey', function(t) {
+    var cardboard = Cardboard(config);
+    var dataset = 'default';
+
+    // Insert 8 features
+    var features = [[1, 1], [1, 2], [2, 1], [2, 2], [-1, -1], [-1, -2], [-2, -1], [-2, -2]].map(function(coords) {
+        return {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'Point',
+                coordinates: coords
+            }
+        };
+    });
+
+    var q = queue();
+
+    features.forEach(function(f) {
+        q.defer(cardboard.put, f, dataset);
+    });
+
+    q.awaitAll(function(err) {
+        t.ifError(err, 'inserted');
+        runQuery();
+    });
+
+    function runQuery() {
+        cardboard.bboxQuadkeyQuery([0,0,2,2], dataset, {maxFeatures:10}, function(err, res) {
+            t.ifError(err, 'bbox paged query');
+            t.equal(res.features.length, 4, ' returned 4 features');
+            var lastEval = { quadkey: res.features[1].quadkey, id: res.features[1].id};
+            cardboard.bboxQuadkeyQuery([0,0,2,2], dataset, {maxFeatures:10, start: lastEval }, function(err, res) {
+                t.ifError(err, 'bbox paged query');
+                t.equal(res.features.length, 2, ' returned 2 features');
+                t.end();
+            });
+        });
+    }
+});
+
+test('teardown', s.teardown);

--- a/test/bbox_queries_compare.test.js
+++ b/test/bbox_queries_compare.test.js
@@ -1,0 +1,181 @@
+var test = require('tape');
+var queue = require('queue-async');
+var Cardboard = require('../');
+var Utils = require('../lib/utils');
+
+var s = require('./setup');
+var config = s.config;
+var utils = new Utils(config);
+var Dyno = require('dyno');
+
+var points = [
+    [0,0], [-120, 30], [-20, 30], [20, 30], [120, 30], [-120, -30],
+    [-20, -30], [20, -30], [120, -30], [-120, 60], [-20, 60],
+    [20, 60], [120, 60], [-120, -60], [-20, -60], [20, -60],[120, -60]
+];
+
+// bboxQuadkeyQuery
+test('setup', s.setup);
+
+test('bboxQuadkeyQuery scan', function(t) {
+    var cardboard = Cardboard(config);
+    var dyno = new Dyno(config);
+    var dataset = 'default';
+
+    var features = points.map(function(coords) {
+        return {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'Point',
+                coordinates: coords
+            }
+        };
+    });
+
+    var queries = [
+        [-1, -1, 1, 1]
+    ];
+
+    var q = queue();
+
+    features.forEach(function(f) {
+        q.defer(cardboard.put, f, dataset);
+    });
+
+    q.awaitAll(function(err) {
+        t.ifError(err, 'inserted');
+        runQueries();
+    });
+
+    function runQueries() {
+        var q = queue();
+
+        queries.forEach(function(query) {
+            function deal(callback) {
+                bboxQuadkeyQuery(query, dataset, function(err, res) {
+                    if (err) return callback(err);
+                    t.equal(res.Items.length, 1, 'expected items');
+                    t.equal(res.ScannedCount, 9, 'expected scan count');
+                    callback();
+                });
+            }
+
+            q.defer(deal);
+        });
+
+        q.await(function(err) {
+            t.ifError(err, 'passed queries');
+            t.end();
+        });
+    }
+
+    function bboxQuadkeyQuery(bbox, dataset, callback) {
+        var quadkeyRange = utils.calcQuadkeyRange(bbox);
+
+        var params = {
+            IndexName: 'quadkey',
+            ExpressionAttributeNames: { '#quadkey': 'quadkey', '#dataset': 'dataset' },
+            ExpressionAttributeValues: {
+                ':nw': quadkeyRange.nw,
+                ':se': quadkeyRange.se,
+                ':dataset': dataset,
+                ':west': bbox[2],
+                ':east': bbox[0],
+                ':north': bbox[1],
+                ':south': bbox[3]
+            },
+            KeyConditionExpression: '#dataset = :dataset and #quadkey BETWEEN :nw and :se',
+            Limit: 100,
+            FilterExpression: 'west <= :west and east >= :east and north >= :north and south <= :south'
+        };
+
+        dyno.query(params, function(err, res) {
+            if (err) return callback(err);
+            return callback(null, res);
+        });
+    }
+});
+
+test('teardown', s.teardown);
+
+// bboxQuery
+test('setup', s.setup);
+
+test('bboxQuery scan', function(t) {
+    var cardboard = Cardboard(config);
+    var dyno = new Dyno(config);
+    var dataset = 'default';
+
+    var features = points.map(function(coords) {
+        return {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'Point',
+                coordinates: coords
+            }
+        };
+    });
+
+    var queries = [
+        [-1, -1, 1, 1]
+    ];
+
+    var q = queue();
+
+    features.forEach(function(f) {
+        q.defer(cardboard.put, f, dataset);
+    });
+
+    q.awaitAll(function(err) {
+        t.ifError(err, 'inserted');
+        runQueries();
+    });
+
+    function runQueries() {
+        var q = queue();
+
+        queries.forEach(function(query) {
+            function deal(callback) {
+                bboxQuery(query, dataset, function(err, res) {
+                    if (err) return callback(err);
+                    t.equal(res.Items.length, 1, 'expected items');
+                    t.equal(res.ScannedCount, 17, 'expected scan count');
+                    callback();
+                });
+            }
+
+            q.defer(deal);
+        });
+
+        q.await(function(err) {
+            t.ifError(err, 'passed queries');
+            t.end();
+        });
+    }
+
+    function bboxQuery(bbox, dataset, callback) {
+        var params = {
+            ExpressionAttributeNames: { '#id': 'id', '#dataset': 'dataset' },
+            ExpressionAttributeValues: {
+                ':id': 'id!',
+                ':dataset': dataset,
+                ':west': bbox[2],
+                ':east': bbox[0],
+                ':north': bbox[1],
+                ':south': bbox[3]
+            },
+            KeyConditionExpression: '#dataset = :dataset and begins_with(#id, :id)',
+            Limit: 100,
+            FilterExpression: 'west <= :west and east >= :east and north >= :north and south <= :south'
+        };
+
+        dyno.query(params, function(err, res) {
+            if (err) return callback(err);
+            return callback(null, res);
+        });
+    }
+});
+
+test('teardown', s.teardown);

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -30,6 +30,7 @@ test('pass preconfigured dyno object', function(t) {
         cardboard.list('default', function(err, items) {
             t.equal(err, null);
             delete items.features[0].id;
+            delete items.features[0].quadkey;
             t.deepEqual(items, { type: 'FeatureCollection', features: [geojson] }, 'one result');
             t.end();
         });

--- a/test/indexing.test.js
+++ b/test/indexing.test.js
@@ -79,6 +79,7 @@ test('insert, get by primary index (small feature)', function(t) {
         cardboard.get(res.id, 'default', function(err, data) {
             t.equal(err, null);
             fixtures.haitiLine.id = res.id;
+            delete data.quadkey;
 
             // round-trip through geobuf will always truncate coords to 6 decimal places
             var f = geobuf.geobufToFeature(geobuf.featureToGeobuf(fixtures.haitiLine).toBuffer());
@@ -120,6 +121,7 @@ test('insert, get by primary index (large feature)', function(t) {
         cardboard.get(res.id, 'default', function(err, data) {
             t.equal(err, null);
             feature.id = res.id;
+            delete data.quadkey;
 
             // round-trip through geobuf will always truncate coords to 6 decimal places
             var f = geobuf.geobufToFeature(geobuf.featureToGeobuf(feature).toBuffer());
@@ -273,7 +275,9 @@ test('insert feature with object property', function(t) {
         cardboard.get(res.id, 'default', function(err, data) {
             t.ifError(err, 'got item');
             d.id = res.id;
-            t.deepEqual(data, geobuf.geobufToFeature(geobuf.featureToGeobuf(d).toBuffer()));
+            var expected = geobuf.geobufToFeature(geobuf.featureToGeobuf(d).toBuffer());
+            expected.quadkey = data.quadkey;
+            t.deepEqual(data, expected);
             t.end();
         });
     });
@@ -301,6 +305,7 @@ test('insert & update', function(t) {
             cardboard.get(putResult.id, 'default', function(err, getResult) {
                 t.ifError(err, 'got record');
                 var f = geobuf.geobufToFeature(geobuf.featureToGeobuf(update).toBuffer());
+                f.quadkey = getResult.quadkey;
                 t.deepEqual(getResult, f, 'expected record');
                 t.end();
             });
@@ -340,6 +345,7 @@ test('insert & delete', function(t) {
         cardboard.get(putResult.id, 'default', function(err, data) {
             t.equal(err, null);
             nullIsland.id = putResult.id;
+            nullIsland.quadkey = putResult.quadkey;
             t.deepEqual(data, nullIsland);
             cardboard.del(putResult.id, 'default', function(err) {
                 t.ifError(err, 'removed');
@@ -368,6 +374,7 @@ test('insert & delDataset', function(t) {
             t.equal(err, null);
             var nullIsland = _.clone(fixtures.nullIsland);
             nullIsland.id = putResult.id;
+            nullIsland.quadkey = putResult.quadkey;
             t.deepEqual(data, nullIsland);
             cardboard.delDataset('default', function(err) {
                 t.equal(err, null);
@@ -423,6 +430,7 @@ test('list', function(t) {
 
         var nullIsland = _.clone(fixtures.nullIsland);
         nullIsland.id = primary.id;
+        nullIsland.quadkey = primary.quadkey;
 
         cardboard.list('default', function(err, data) {
             t.deepEqual(data.features.length, 1);
@@ -811,6 +819,7 @@ test('Insert feature with id specified by user', function(t) {
         t.deepEqual(putResult.id, haiti.id, 'Uses given id');
         cardboard.get(haiti.id, 'default', function(err, feature) {
             var f = geobuf.geobufToFeature(geobuf.featureToGeobuf(haiti).toBuffer());
+            f.quadkey = putResult.quadkey;
             t.deepEqual(feature, f, 'retrieved record');
             t.end();
         });
@@ -831,10 +840,12 @@ test('Insert with and without ids specified', function(t) {
 
         cardboard.get(haiti.id, 'default', function(err, feature) {
             var f = geobuf.geobufToFeature(geobuf.featureToGeobuf(haiti).toBuffer());
+            f.quadkey = putResults.features[0].quadkey;
             t.deepEqual(feature, f, 'retrieved record');
             cardboard.get(putResults.features[1].id, 'default', function(err, feature) {
-                var f = _.extend({ id: putResults.features[1].id }, fixtures.haiti);
+                var f = _.extend({id: putResults.features[1].id }, fixtures.haiti);
                 f = geobuf.geobufToFeature(geobuf.featureToGeobuf(f).toBuffer());
+                f.quadkey = putResults.features[1].quadkey;
                 t.deepEqual(feature, f, 'retrieved record');
                 t.end();
             });


### PR DESCRIPTION
To avoid full table scans on large datasets, created a quadkey local secondary index based on a feature's center point to roughly filter features between the bbox's northwest and southeast points.  The quadkey query is `cardboard.bboxQuadkeyQuery` method with tests.

Also, sorry this pr is a so verbose.