### PR TITLE
Apply a set of changes to metadata record

### DIFF
--- a/index.js
+++ b/index.js
@@ -528,6 +528,18 @@ function Cardboard(config) {
         Metadata(config.dyno, dataset).deleteFeature(feature, callback);
     };
 
+    /**
+     * Perform all required metadata updates for a set of changes to features in a dataset. This operation **will** create a metadata record if one does not exist.
+     * @static
+     * @memberof cardboard.metadata
+     * @param {string} dataset - the name of the dataset
+     * @param {array} changes - a set of changes. Each change must have an `.action` property, and `.new`, `.old`, or both.
+     * @param {function} callback - a function fired when all changes have been implemented
+     */
+    metadata.applyChanges = function(dataset, changes, callback) {
+        Metadata(config.dyno, dataset).applyChanges(changes, callback);
+    };
+    
     cardboard.metadata = metadata;
 
     /**

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -185,12 +185,13 @@ function Metadata(dyno, dataset) {
         var params = {
             Key: key,
             ExpressionAttributeNames: { '#id': 'id', '#u': 'updated', '#e': 'editcount' },
-            ExpressionAttributeValues: { ':u': +new Date(), ':e': 1 },
+            ExpressionAttributeValues: { ':u': +new Date(), ':e': properties.edits || 1 },
             UpdateExpression: 'set #u = :u add #e :e',
             ConditionExpression: 'attribute_exists(#id)'
         };
 
         Object.keys(properties).forEach(function(key, i) {
+            if (key === 'edits') return;
             params.ExpressionAttributeNames['#' + i] = key;
             params.ExpressionAttributeValues[':' + i] = properties[key];
             params.UpdateExpression += ', #' + i + ' ' + ':' + i;
@@ -220,6 +221,61 @@ function Metadata(dyno, dataset) {
                 });
         });
     };
+
+    /**
+     * Perform all required metadata updates for a set of changes to features in a dataset. This operation **will** create a metadata record if one does not exist.
+     * @private
+     * @param {array} changes - a set of changes. Each change must have an `.action` property, and `.new`, `.old`, or both.
+     * @param {function} callback - a function fired when all changes have been implemented
+     */
+    metadata.applyChanges = function(changes, callback) {
+        metadata.defaultInfo(function(err) {
+            if (err) return callback(err);
+
+            var bounds = [18000, 9000, -18000, -9000];
+            var size = 0;
+            var count = 0;
+
+            changes.forEach(function(change) {
+                if (change.action === 'INSERT') {
+                    var newInfo = isDatabaseRecord(change.new) ? change.new : metadata.getFeatureInfo(change.new);
+                    size += newInfo.size;
+
+                    bounds[0] = Math.min(bounds[0], newInfo.west);
+                    bounds[1] = Math.min(bounds[1], newInfo.south);
+                    bounds[2] = Math.max(bounds[2], newInfo.east);
+                    bounds[3] = Math.max(bounds[3], newInfo.north);
+
+                    count++;
+                }
+
+                if (change.action === 'MODIFY') {
+                    var fromInfo = isDatabaseRecord(change.old) ? change.old : metadata.getFeatureInfo(change.old);
+                    var toInfo = isDatabaseRecord(change.new) ? change.new : metadata.getFeatureInfo(change.new);
+                    size += (toInfo.size - fromInfo.size);
+
+                    bounds[0] = Math.min(bounds[0], toInfo.west);
+                    bounds[1] = Math.min(bounds[1], toInfo.south);
+                    bounds[2] = Math.max(bounds[2], toInfo.east);
+                    bounds[3] = Math.max(bounds[3], toInfo.north);
+                }
+
+                if (change.action === 'REMOVE') {
+                    var deletedInfo = isDatabaseRecord(change.old) ? change.old : metadata.getFeatureInfo(change.old);
+                    size -= deletedInfo.size;
+                    count--;
+                }
+            });
+
+            queue()
+                .defer(metadata.adjustProperties, { count: count, size: size, edits: changes.length })
+                .defer(metadata.adjustBounds, bounds)
+                .awaitAll(function(err) {
+                    if (err) return callback(err);
+                    callback();
+                });
+        });
+    }
 
     /**
      * Given before and after states of a GeoJSON feature, perform all required metadata adjustments. This operation **will not** create a metadata record if one does not exist.

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -828,3 +828,108 @@ test('calculateDatasetInfo', function(t) {
 });
 
 test('teardown', s.teardown);
+
+test('setup', s.setup);
+
+test('metadata.applyChanges', function(t) {
+    var original = {
+        dataset: dataset,
+        id: 'metadata!' + dataset,
+        editcount: 1,
+        updated: 1471645277837,
+        count: 2,
+        size: 200,
+        west: -5,
+        south: -5,
+        east: 5,
+        north: 5
+    };
+
+    var changes = [
+        {
+            action: 'INSERT',
+            new: {
+                dataset: dataset,
+                id: '1',
+                cell: '01',
+                size: 150,
+                west: -6,
+                south: -6,
+                east: 4,
+                north: 4
+            }
+        },
+        {
+            action: 'MODIFY',
+            new: {
+                dataset: dataset,
+                id: '2',
+                cell: '01',
+                size: 10,
+                west: -4,
+                south: -4,
+                east: 6,
+                north: 6
+            },
+            old: {
+                dataset: dataset,
+                id: '2',
+                cell: '01',
+                size: 100,
+                west: -5,
+                south: -5,
+                east: 4,
+                north: 4
+            }
+        },
+        {
+            action: 'REMOVE',
+            old: {
+                dataset: dataset,
+                id: '3',
+                cell: '01',
+                size: 100,
+                west: -4,
+                south: -4,
+                east: 5,
+                north: 5
+            }
+        }
+    ];
+
+    var expected = {
+        dataset: dataset,
+        id: 'metadata!dataset',
+        editcount: 4,
+        count: 2,
+        size: 160,
+        west: -6,
+        south: -6,
+        east: 6,
+        north: 6
+    };
+
+    dyno.putItem({ Item: original }, function(err) {
+        if (err) throw err;
+
+        metadata.applyChanges(changes, function(err) {
+            if (err) throw err;
+
+            dyno.getItem({ Key: { dataset: dataset, id: 'metadata!' + dataset } }, function(err, data) {
+                if (err) throw err;
+
+                var info = data.Item;
+                t.equal(info.editcount, expected.editcount, 'expected editcount');
+                t.equal(info.count, expected.count, 'expected count');
+                t.equal(info.size, expected.size, 'expected size');
+                t.equal(info.west, expected.west, 'expected west');
+                t.equal(info.south, expected.south, 'expected south');
+                t.equal(info.east, expected.east, 'expected east');
+                t.equal(info.north, expected.north, 'expected north');
+                t.end();
+            });
+        });
+    });
+});
+
+test('teardown', s.teardown);


### PR DESCRIPTION
Provides a function to update a dataset's metadata record based on an arbitrary number of feature changes, rather than one-by-one.

The existing functions require 5 DynamoDB requests per feature that was added, modified, or changed. This function allows any size batch of feature changes to be applied to the metadata in 5 requests. This should be much much faster.

cc @mcwhittemore @samanpwbb @davidtheclark 
