### PR TITLE
Split cardboard up across two tables

### DIFF
--- a/lib/features_table.json
+++ b/lib/features_table.json
@@ -1,0 +1,12 @@
+{
+    "AttributeDefinitions": [
+        {"AttributeName": "id", "AttributeType": "S"}
+    ],
+    "KeySchema": [
+        {"AttributeName": "id", "KeyType": "HASH"}
+    ],
+    "ProvisionedThroughput": {
+        "ReadCapacityUnits": 5,
+        "WriteCapacityUnits": 50
+    }
+}

--- a/lib/search_table.json
+++ b/lib/search_table.json
@@ -1,0 +1,14 @@
+{
+    "AttributeDefinitions": [
+        {"AttributeName": "collection", "AttributeType": "S"},
+        {"AttributeName": "index", "AttributeType": "S"}
+    ],
+    "KeySchema": [
+        {"AttributeName": "collection", "KeyType": "HASH"},
+        {"AttributeName": "index", "KeyType": "RANGE"}
+    ],
+    "ProvisionedThroughput": {
+        "ReadCapacityUnits": 5,
+        "WriteCapacityUnits": 50
+    }
+}


### PR DESCRIPTION
The goal of this PR is to resolve hot partition problems as outlined in https://github.com/mapbox/cardboard/issues/184.

Things to consider:

- Designing the table used for listing features to work for other kinds of search
- Do we really need streams? This would take more config to run the default install than currently
- Are we cool with dropping bbox from this for now? I sort of want bbox to be its own project.

