### PR TITLE
Accept any 2.x aws-sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/mapbox/cardboard",
   "dependencies": {
-    "aws-sdk": "^2.5.3",
+    "aws-sdk": "2.x",
     "cuid": "1.2.4",
     "dyno": "1.2.0",
     "geobuf": "0.2.5",


### PR DESCRIPTION
This is to encourage de-duping (less conflict with other downstream deps that use aws-sdk and cardboard)