### PR TITLE
dyno@1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "aws-sdk": "^2.5.3",
     "cuid": "1.2.4",
-    "dyno": "1.2.0",
+    "dyno": "1.4.1",
     "geobuf": "0.2.5",
     "geojson-extent": "^0.1.0",
     "geojson-normalize": "0.0.0",


### PR DESCRIPTION
Our change to npm 3 (node 6) in upstream dependencies surfaced that our duplicate module test fails on the new npm install behavior. This updates dyno in cardboard to match upstream version locks.

cc/ @mcwhittemore 