### PR TITLE
aws sdk v3 upgrade

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-- '4.5'
-- '6.9'
-sudo: false
-script:
-- npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v4.0.0
+
+- Migrate from AWS SDK for JavaScript v2 to v3. Removes the `aws-sdk` and `@mapbox/dyno` dependencies in favor of `@aws-sdk/client-dynamodb`, `@aws-sdk/lib-dynamodb`, and `@aws-sdk/util-dynamodb`.
+- **Breaking:** the `dyno` configuration option (a preconfigured `@mapbox/dyno` client) has been replaced by `dynamodb`, a preconfigured `DynamoDBDocumentClient`.
+- **Breaking:** removed the unused `bucket`, `prefix`, and `s3` configuration options and the corresponding CLI flags/env vars, which had been dead since the v3.0.0 architecture split.
+- **Breaking:** requires Node.js >= 18.
+
 # v3.0.6
 
 - Replace dyno with @mapbox/dyno and upgrade to v1.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Migrate from AWS SDK for JavaScript v2 to v3. Removes the `aws-sdk` and `@mapbox/dyno` dependencies in favor of `@aws-sdk/client-dynamodb`, `@aws-sdk/lib-dynamodb`, and `@aws-sdk/util-dynamodb`.
 - **Breaking:** the `dyno` configuration option (a preconfigured `@mapbox/dyno` client) has been replaced by `dynamodb`, a preconfigured `DynamoDBDocumentClient`.
 - **Breaking:** removed the unused `bucket`, `prefix`, and `s3` configuration options and the corresponding CLI flags/env vars, which had been dead since the v3.0.0 architecture split.
-- **Breaking:** requires Node.js >= 18.
+- **Breaking:** requires Node.js >= 20.
 
 # v3.0.6
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 > **`cardboard` is under minimal security maintenance and not being actively developed.**
 >
 > While the default branch contains the latest 3.x release, many projects were never upgraded to the new v3 API and remain on 2.x. There is a [v2x branch](https://github.com/mapbox/cardboard/tree/v2x) that will receive similar security updates and new NPM package versions as v3.x for the near future, but will likely be deprecated in 2026 or 2027. If you rely on `cardboard`, please plan accordingly and use at your own risk.
+>
+> As of `4.0.0`, cardboard uses AWS SDK for JavaScript v3 and requires Node.js >= 18. The `dyno` configuration option (a preconfigured [dyno](https://github.com/mapbox/dyno) client) has been replaced by `dynamodb`, a preconfigured [`DynamoDBDocumentClient`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lib-dynamodb/).
 
 [![Build Status](https://travis-ci.org/mapbox/cardboard.svg?branch=master)](https://travis-ci.org/mapbox/cardboard) [![Coverage Status](https://coveralls.io/repos/mapbox/cardboard/badge.svg?branch=master)](https://coveralls.io/r/mapbox/cardboard?branch=master)
 
@@ -26,11 +28,11 @@ region | X | the region containing the given DynamoDB table
 accessKeyId | | AWS credentials
 secretAccessKey | | AWS credentials
 sessionToken | | AWS credentials
-dyno | | a pre-configured [dyno client](https://github.com/mapbox/dyno) to use for DynamoDB interactions
+dynamodb | | a pre-configured [DynamoDBDocumentClient](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lib-dynamodb/) to use for DynamoDB interactions
 
-Providing AWS credentials is optional. Cardboard depends on the AWS SDK for JavaScript, and so credentials can be provided in any way supported by that library. See [configuring the SDK in Node.js](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html) for more configuration options.
+Providing AWS credentials is optional. Cardboard depends on the AWS SDK for JavaScript v3, and so credentials can be provided in any way supported by that library. See [configuring the SDK in Node.js](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html) for more configuration options.
 
-If you provide a preconfigured [dyno client](https://github.com/mapbox/dyno), you do not need to specify `table` and `region` when initializing cardboard.
+If you provide a preconfigured `dynamodb` client, you do not need to specify `mainTable` and `region` when initializing cardboard.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dynamodb | | a pre-configured [DynamoDBDocumentClient](https://docs.aws.amazon.c
 
 Providing AWS credentials is optional. Cardboard depends on the AWS SDK for JavaScript v3, and so credentials can be provided in any way supported by that library. See [configuring the SDK in Node.js](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html) for more configuration options.
 
-If you provide a preconfigured `dynamodb` client, you do not need to specify `mainTable` and `region` when initializing cardboard.
+If you provide a preconfigured `dynamodb` client, you do not need to specify `region` when initializing cardboard.
 
 #### Example
 

--- a/bin/cardboard.js
+++ b/bin/cardboard.js
@@ -15,12 +15,6 @@ function configLoader(args, env) {
     config.mainTable = args.mainTable || env.CardboardMainTable;
     if (!config.mainTable) throw new Error('You must provide a features table name');
 
-    config.bucket = args.bucket || env.CardboardBucket;
-    if (!config.bucket) throw new Error('You must provide an S3 bucket');
-
-    config.prefix = args.prefix || env.CardboardPrefix;
-    if (!config.prefix) throw new Error('You must provide an S3 prefix');
-
     if (args.endpoint || env.CardboardEndpoint) {
         config.endpoint = args.endpoint || env.CardboardEndpoint;
     }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function Cardboard(config) {
     config = config || {};
 
     // Allow caller to pass in an aws-sdk client
-    if (!config.dynamodb && (typeof config.mainTable !== 'string' || config.mainTable.length === 0)) throw new Error('"mainTable" must be a string');
+    if (typeof config.mainTable !== 'string' || config.mainTable.length === 0) throw new Error('"mainTable" must be a string');
     if (!config.dynamodb && !config.region) throw new Error('No region set');
     if (!config.dynamodb) {
         var clientConfig = { region: config.region, endpoint: config.endpoint };

--- a/index.js
+++ b/index.js
@@ -32,6 +32,12 @@ function Cardboard(config) {
                 secretAccessKey: config.secretAccessKey,
                 sessionToken: config.sessionToken
             };
+        } else if (config.endpoint) {
+            // Local/custom endpoints (dynalite, DynamoDB Local, etc.) don't
+            // validate credentials, but the SDK still requires some to be
+            // resolvable rather than falling through to the (possibly empty)
+            // default provider chain.
+            clientConfig.credentials = { accessKeyId: 'local', secretAccessKey: 'local' };
         }
         config.dynamodb = DynamoDBDocumentClient.from(new DynamoDBClient(clientConfig));
     }

--- a/index.js
+++ b/index.js
@@ -1,25 +1,40 @@
-var Dyno = require('@mapbox/dyno');
+var DynamoDBClient = require('@aws-sdk/client-dynamodb').DynamoDBClient;
+var CreateTableCommand = require('@aws-sdk/client-dynamodb').CreateTableCommand;
+var ResourceInUseException = require('@aws-sdk/client-dynamodb').ResourceInUseException;
+var DynamoDBDocumentClient = require('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+var dynamoBatch = require('./lib/dynamo-batch');
 
 module.exports = Cardboard;
 
 /**
  * Cardboard client generator
  * @param {object} config - a configuration object
- * @param {string} config.dyno - the name of a DynamoDB table to connect to
+ * @param {string} config.mainTable - the name of a DynamoDB table to connect to
  * @param {string} config.region - the AWS region containing the DynamoDB table
- * @param {string} config.bucket - the name of an S3 bucket to use
- * @param {string} config.prefix - the name of a folder within the indicated S3 bucket
- * @param {dyno} [config.dyno] - a pre-configured [dyno client](https://github.com/mapbox/dyno) for connecting to DynamoDB
- * @param {s3} [config.s3] - a pre-configured [S3 client](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html)
+ * @param {string} [config.endpoint] - an alternate DynamoDB endpoint to connect to
+ * @param {string} [config.accessKeyId] - AWS credentials
+ * @param {string} [config.secretAccessKey] - AWS credentials
+ * @param {string} [config.sessionToken] - AWS credentials
+ * @param {DynamoDBDocumentClient} [config.dynamodb] - a pre-configured [DynamoDBDocumentClient](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lib-dynamodb/) for connecting to DynamoDB
  * @returns {cardboard} a cardboard client
  */
 function Cardboard(config) {
     config = config || {};
 
-    // Allow caller to pass in aws-sdk clients
-    if (!config.dyno && (typeof config.mainTable !== 'string' || config.mainTable.length === 0)) throw new Error('"mainTable" must be a string');
-    if (!config.dyno && !config.region) throw new Error('No region set');
-    if (!config.dyno) config.dyno = Dyno({table: config.mainTable, region: config.region, endpoint: config.endpoint});
+    // Allow caller to pass in an aws-sdk client
+    if (!config.dynamodb && (typeof config.mainTable !== 'string' || config.mainTable.length === 0)) throw new Error('"mainTable" must be a string');
+    if (!config.dynamodb && !config.region) throw new Error('No region set');
+    if (!config.dynamodb) {
+        var clientConfig = { region: config.region, endpoint: config.endpoint };
+        if (config.accessKeyId && config.secretAccessKey) {
+            clientConfig.credentials = {
+                accessKeyId: config.accessKeyId,
+                secretAccessKey: config.secretAccessKey,
+                sessionToken: config.sessionToken
+            };
+        }
+        config.dynamodb = DynamoDBDocumentClient.from(new DynamoDBClient(clientConfig));
+    }
 
     var utils = require('./lib/utils');
 
@@ -56,7 +71,7 @@ function Cardboard(config) {
             return { PutRequest: { Item: record } };
         });
 
-        config.dyno.batchWriteItemRequests(params).sendAll(10, function(err, results) {
+        dynamoBatch.batchWrite(config.dynamodb, config.mainTable, params.RequestItems[config.mainTable], function(err, results) {
             if (err) return callback(err);
 
             var unprocessed = results.reduce(function(memo, result) {
@@ -100,7 +115,7 @@ function Cardboard(config) {
 
         if(err) return callback(err);
 
-        config.dyno.batchWriteItemRequests(params).sendAll(10, function(err, results) {
+        dynamoBatch.batchWrite(config.dynamodb, config.mainTable, params.RequestItems[config.mainTable], function(err, results) {
             if (err) return callback(err);
 
             var unprocessed = results.reduce(function(memo, result) {
@@ -127,11 +142,8 @@ function Cardboard(config) {
 
         var keys = input.map(function(id) { return utils.createFeatureKey(dataset, id); });
 
-        var params = { RequestItems: {}};
-        params.RequestItems[config.mainTable] = { Keys: keys };
-
-        config.dyno.batchGetItemRequests(params).sendAll(10, function(err, results) {
-            if (err) return callback(err[0]);
+        dynamoBatch.batchGet(config.dynamodb, config.mainTable, keys, function(err, results) {
+            if (err) return callback(err);
             var features = results.reduce(function(memo, result) {
                 var res = result.Responses ? result.Responses[config.mainTable] : [];
                 return memo.concat(res);
@@ -162,7 +174,14 @@ function Cardboard(config) {
     cardboard.createTable = function(callback) {
         var tableSchema = require('./lib/main-table.json');
         tableSchema.TableName = config.mainTable;
-        config.dyno.createTable(tableSchema, callback);
+        config.dynamodb.send(new CreateTableCommand(tableSchema)).then(function(data) {
+            callback(null, data);
+        }, function(err) {
+            // A table with this name already existing is not an error: callers
+            // are free to point cardboard at a pre-existing table.
+            if (err instanceof ResourceInUseException) return callback(null);
+            callback(err);
+        });
     };
 
     return cardboard;

--- a/lib/dynamo-batch.js
+++ b/lib/dynamo-batch.js
@@ -3,8 +3,6 @@ var BatchGetCommand = require('@aws-sdk/lib-dynamodb').BatchGetCommand;
 
 var WRITE_BATCH_SIZE = 25;
 var GET_BATCH_SIZE = 100;
-// Bounded retries: any items still unprocessed after this are surfaced to the
-// caller as `pending`, matching cardboard's existing partial-success contract.
 var MAX_RETRIES = 4;
 var CONCURRENCY = 10;
 
@@ -21,8 +19,6 @@ function backoffDelay(attempt) {
     return Math.min(50 * Math.pow(2, attempt), 5000);
 }
 
-// Runs an array of (callback-taking) task functions with a concurrency cap,
-// collecting one result per task in the original order.
 function runWithConcurrency(tasks, concurrency, callback) {
     var results = new Array(tasks.length);
     var index = 0;

--- a/lib/dynamo-batch.js
+++ b/lib/dynamo-batch.js
@@ -1,0 +1,138 @@
+var BatchWriteCommand = require('@aws-sdk/lib-dynamodb').BatchWriteCommand;
+var BatchGetCommand = require('@aws-sdk/lib-dynamodb').BatchGetCommand;
+
+var WRITE_BATCH_SIZE = 25;
+var GET_BATCH_SIZE = 100;
+// Bounded retries: any items still unprocessed after this are surfaced to the
+// caller as `pending`, matching cardboard's existing partial-success contract.
+var MAX_RETRIES = 4;
+var CONCURRENCY = 10;
+
+module.exports.batchWrite = batchWrite;
+module.exports.batchGet = batchGet;
+
+function chunk(array, size) {
+    var chunks = [];
+    for (var i = 0; i < array.length; i += size) chunks.push(array.slice(i, i + size));
+    return chunks;
+}
+
+function backoffDelay(attempt) {
+    return Math.min(50 * Math.pow(2, attempt), 5000);
+}
+
+// Runs an array of (callback-taking) task functions with a concurrency cap,
+// collecting one result per task in the original order.
+function runWithConcurrency(tasks, concurrency, callback) {
+    var results = new Array(tasks.length);
+    var index = 0;
+    var active = 0;
+    var settled = false;
+
+    if (tasks.length === 0) return callback(null, results);
+
+    function next() {
+        if (settled) return;
+        if (index >= tasks.length && active === 0) {
+            settled = true;
+            return callback(null, results);
+        }
+
+        while (active < concurrency && index < tasks.length) {
+            (function(i) {
+                active++;
+                tasks[i](function(err, result) {
+                    active--;
+                    if (settled) return;
+                    if (err) {
+                        settled = true;
+                        return callback(err);
+                    }
+                    results[i] = result;
+                    next();
+                });
+            })(index++);
+        }
+    }
+
+    next();
+}
+
+/**
+ * Writes a set of PutRequest/DeleteRequest objects to a table, chunking into
+ * batches of 25 and retrying unprocessed items with exponential backoff.
+ * @param {DynamoDBDocumentClient} client
+ * @param {string} tableName
+ * @param {object[]} requests - PutRequest/DeleteRequest objects
+ * @param {function} callback - (err, results), where each result has the shape
+ * `{ UnprocessedItems: { RequestItems: { [tableName]: [...requests] } } }`
+ */
+function batchWrite(client, tableName, requests, callback) {
+    var tasks = chunk(requests, WRITE_BATCH_SIZE).map(function(requestChunk) {
+        return function(done) {
+            sendBatchWriteWithRetry(client, tableName, requestChunk, 0, done);
+        };
+    });
+
+    runWithConcurrency(tasks, CONCURRENCY, callback);
+}
+
+function sendBatchWriteWithRetry(client, tableName, requests, attempt, callback) {
+    var params = { RequestItems: {} };
+    params.RequestItems[tableName] = requests;
+
+    client.send(new BatchWriteCommand(params)).then(function(data) {
+        var unprocessed = (data.UnprocessedItems && data.UnprocessedItems[tableName]) || [];
+
+        if (unprocessed.length === 0 || attempt >= MAX_RETRIES) {
+            var result = { UnprocessedItems: { RequestItems: {} } };
+            result.UnprocessedItems.RequestItems[tableName] = unprocessed;
+            return callback(null, result);
+        }
+
+        setTimeout(function() {
+            sendBatchWriteWithRetry(client, tableName, unprocessed, attempt + 1, callback);
+        }, backoffDelay(attempt));
+    }, callback);
+}
+
+/**
+ * Reads a set of keys from a table, chunking into batches of 100 and retrying
+ * unprocessed keys with exponential backoff.
+ * @param {DynamoDBDocumentClient} client
+ * @param {string} tableName
+ * @param {object[]} keys
+ * @param {function} callback - (err, results), where each result has the shape
+ * `{ Responses: { [tableName]: [...items] }, UnprocessedKeys: { [tableName]: { Keys: [...keys] } } }`
+ */
+function batchGet(client, tableName, keys, callback) {
+    var tasks = chunk(keys, GET_BATCH_SIZE).map(function(keyChunk) {
+        return function(done) {
+            sendBatchGetWithRetry(client, tableName, keyChunk, [], 0, done);
+        };
+    });
+
+    runWithConcurrency(tasks, CONCURRENCY, callback);
+}
+
+function sendBatchGetWithRetry(client, tableName, keys, collected, attempt, callback) {
+    var params = { RequestItems: {} };
+    params.RequestItems[tableName] = { Keys: keys };
+
+    client.send(new BatchGetCommand(params)).then(function(data) {
+        var responses = (data.Responses && data.Responses[tableName]) || [];
+        var allItems = collected.concat(responses);
+        var unprocessedKeys = (data.UnprocessedKeys && data.UnprocessedKeys[tableName] && data.UnprocessedKeys[tableName].Keys) || [];
+
+        if (unprocessedKeys.length === 0 || attempt >= MAX_RETRIES) {
+            var result = { Responses: {}, UnprocessedKeys: {} };
+            result.Responses[tableName] = allItems;
+            result.UnprocessedKeys[tableName] = { Keys: unprocessedKeys };
+            return callback(null, result);
+        }
+
+        setTimeout(function() {
+            sendBatchGetWithRetry(client, tableName, unprocessedKeys, allItems, attempt + 1, callback);
+        }, backoffDelay(attempt));
+    }, callback);
+}

--- a/lib/stream-helper.js
+++ b/lib/stream-helper.js
@@ -1,8 +1,8 @@
-var Dyno = require('@mapbox/dyno');
+var unmarshall = require('@aws-sdk/util-dynamodb').unmarshall;
 
 /**
  * Sets up a stream handler by filtering out actions that don't target the desired actions
- * converting the features into Dyno records
+ * converting the features into plain JS records
  * and passing them onto a user provided recordHandler if there are features
  * that match all of the above filters
  */
@@ -11,9 +11,9 @@ module.exports = function streamHelper(allowedActions, recordHandler) {
         var records = event.Records.map(function(record) {
             var change = {};
             change.before = record.dynamodb.OldImage ?
-                Dyno.deserialize(JSON.stringify(record.dynamodb.OldImage)) : undefined;
+                unmarshall(record.dynamodb.OldImage) : undefined;
             change.after = record.dynamodb.NewImage ?
-                Dyno.deserialize(JSON.stringify(record.dynamodb.NewImage)) : undefined;
+                unmarshall(record.dynamodb.NewImage) : undefined;
             change.action = record.eventName;
             return change;
         }).filter(function(change) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,9 @@
 var geobuf = require('geobuf');
 var Pbf = require('pbf');
-var geojsonNormalize = require('geojson-normalize');
+var geojsonNormalize = require('@mapbox/geojson-normalize');
 var _ = require('lodash');
 var bufferFrom = require('buffer-from');
-var cuid = require('cuid');
+var createId = require('@paralleldrive/cuid2').createId;
 
 var utils = module.exports = {};
 
@@ -62,7 +62,7 @@ utils.featureCollection = function(records) {
  */
 utils.toDatabaseRecord = function(feature, dataset) {
     if (feature.id === 0) feature.id = '0';
-    var f = feature.id ? _.clone(feature) : _.extend({}, feature, { id: cuid() });
+    var f = feature.id ? _.clone(feature) : _.extend({}, feature, { id: createId() });
     f.id = ''+f.id;
 
     if (!f.geometry) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,17 +13,15 @@
         "@aws-sdk/lib-dynamodb": "^3.0.0",
         "@aws-sdk/util-dynamodb": "^3.0.0",
         "@mapbox/geojson-extent": "^1.0.1",
+        "@mapbox/geojson-normalize": "^0.0.1",
+        "@paralleldrive/cuid2": "^2.2.2",
         "buffer-from": "^0.1.1",
-        "cuid": "1.2.4",
         "geobuf": "^3.0.0",
-        "geojson-normalize": "0.0.0",
         "lodash": "^4.17.23",
         "minimist": "^1.2.8",
         "pbf": "^3.0.4",
-        "queue-async": "~1.0.7",
-        "sphericalmercator": "^1.0.3",
-        "through2": "^2.0.0",
-        "tilebelt": "^0.5.2"
+        "queue-async": "^1.2.1",
+        "through2": "^2.0.0"
       },
       "bin": {
         "cardboard": "bin/cardboard.js"
@@ -646,6 +644,13 @@
         "node": ">=16"
       }
     },
+    "node_modules/@mapbox/dyno/node_modules/queue-async": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.0.7.tgz",
+      "integrity": "sha512-V52kIzNbnCsKw0ezR1zuDWnd3o2CsIloZzPP7pvgxeRRo7f6E+HzMfePecZKolqHi30xEZQhfOpGQ7VWqEYFaQ==",
+      "deprecated": "renamed to d3-queue",
+      "dev": true
+    },
     "node_modules/@mapbox/extent": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@mapbox/extent/-/extent-0.4.0.tgz",
@@ -684,6 +689,27 @@
       "license": "ISC",
       "bin": {
         "geojson-normalize": "geojson-normalize"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@smithy/core": {
@@ -2232,15 +2258,6 @@
       },
       "engines": {
         "node": ">=0.10.40"
-      }
-    },
-    "node_modules/cuid": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/cuid/-/cuid-1.2.4.tgz",
-      "integrity": "sha512-5bOF1NPGIGzHoFHQ5ESoquB0w56gvemG1vXFGSodrJjkjBvP4CHgIEt+3UQ+DpZL5hgGR7ieTU7Ah/Ey05PdbQ==",
-      "deprecated": "Cuid and other k-sortable and non-cryptographic ids (Ulid, ObjectId, KSUID, all UUIDs) are all insecure. Use @paralleldrive/cuid2 instead.",
-      "engines": {
-        "node": "~0.x.x"
       }
     },
     "node_modules/d": {
@@ -4200,13 +4217,6 @@
       "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-1.1.1.tgz",
       "integrity": "sha512-k/6BCd0qAt7vdqdM1LkLfAy72EsLDy0laNwX0x2h49vfYCiQkRc4PSra8DNEdJ10EKRpwEvDXMb0dBknTJuWpQ==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/geojson-normalize": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/geojson-normalize/-/geojson-normalize-0.0.0.tgz",
-      "integrity": "sha512-h/ldgc7C2DrYDIn+F/o+AgZLxmeC+O4q3wvGwiuBjTTRnhxvxaGz6cE6cRTeMH89jIJM3BiP+R6Yiht7f3PBuA==",
-      "deprecated": "This module is now under the @mapbox namespace: install @mapbox/geojson-normalize instead",
-      "license": "ISC"
     },
     "node_modules/geojson-random": {
       "version": "0.2.2",
@@ -6371,9 +6381,9 @@
       "license": "MIT"
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash._arraycopy": {
@@ -10797,10 +10807,10 @@
       }
     },
     "node_modules/queue-async": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.0.7.tgz",
-      "integrity": "sha512-V52kIzNbnCsKw0ezR1zuDWnd3o2CsIloZzPP7pvgxeRRo7f6E+HzMfePecZKolqHi30xEZQhfOpGQ7VWqEYFaQ==",
-      "deprecated": "renamed to d3-queue"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.2.1.tgz",
+      "integrity": "sha512-aPVvlovU79BlPPgEiroL5XO57lZy1WrnyypfpGy25O+VQBbjOgr4XZYL/JVPuYN1zQO0oEH3bd1ZPRPO/nqZ5A==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/quote-stream": {
       "version": "1.0.2",
@@ -12260,18 +12270,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/sphericalmercator": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sphericalmercator/-/sphericalmercator-1.0.5.tgz",
-      "integrity": "sha512-3YpbhilnWV4kp2xuFkpCat+kg2NcK7aa82rHfYU8MgwvSUug4vrWf+4AlA9f08Ae4hoe4W6DethROG4kTMepKg==",
-      "deprecated": "This module is now under the @mapbox namespace: install @mapbox/sphericalmercator instead",
-      "bin": {
-        "bbox": "bin/bbox.js",
-        "to4326": "bin/to4326.js",
-        "to900913": "bin/to900913.js",
-        "xyz": "bin/xyz.js"
-      }
-    },
     "node_modules/split": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
@@ -13129,16 +13127,6 @@
         "xtend": "~4.0.0"
       }
     },
-    "node_modules/tilebelt": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/tilebelt/-/tilebelt-0.5.3.tgz",
-      "integrity": "sha512-f1ofxWr5l+iAROpqJ+SBkL+RrZDordWD990hWl5bt99R8Z4D3gzGx91jbuSk9ZNe5r3nWTMv6+X5BO1uyIlurw==",
-      "deprecated": "This module is now under the @mapbox namespace: install @mapbox/tilebelt instead",
-      "license": "MIT",
-      "dependencies": {
-        "turf-bbox-polygon": "^0.1.5"
-      }
-    },
     "node_modules/to-buffer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
@@ -13364,22 +13352,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/turf-bbox-polygon": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/turf-bbox-polygon/-/turf-bbox-polygon-0.1.5.tgz",
-      "integrity": "sha512-EBpCKEuo7YMCcslJwph8u5KWcPtdj7UAEiGWMil1YYhKoXdBJbTykKdu2KNFUmfSJIdFKmDQA4aBcnLe5anpcQ==",
-      "deprecated": "Turf packages are now namespaced: please use @turf/bbox-polygon instead",
-      "license": "MIT",
-      "dependencies": {
-        "turf-polygon": "^0.1.1"
-      }
-    },
-    "node_modules/turf-polygon": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/turf-polygon/-/turf-polygon-0.1.1.tgz",
-      "integrity": "sha512-xTxcwJ5+PRTiLSBwHKlLgdouXgMVeGW0dSw+HZ9GxEUKng0OZQ5vtS1uxUCk5iYP1F4NLcUwMuTW5rYNesJ01g==",
-      "license": "MIT"
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@mapbox/cardboard",
-  "version": "3.0.6",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/cardboard",
-      "version": "3.0.6",
+      "version": "4.0.0",
       "license": "ISC",
       "dependencies": {
-        "@mapbox/dyno": "^1.6.3",
+        "@aws-sdk/client-dynamodb": "^3.0.0",
+        "@aws-sdk/lib-dynamodb": "^3.0.0",
+        "@aws-sdk/util-dynamodb": "^3.0.0",
         "@mapbox/geojson-extent": "^1.0.1",
-        "aws-sdk": "2.x",
         "buffer-from": "^0.1.1",
         "cuid": "1.2.4",
         "geobuf": "^3.0.0",
@@ -36,244 +37,29 @@
         "geojson-fixtures": "0.1.0",
         "geojson-random": "^0.2.2",
         "geojson-stream": "0.0.0",
-        "mock-aws-s3": "^0.2.1",
         "nyc": "^6.4.4",
         "tape": "^4.6.3"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.978.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.978.0.tgz",
-      "integrity": "sha512-1EbLVTq55pI9YCXzg9vdAx09hJOXpxQPIcCXNMdrvKga7eMIkGXR95Oc9HMOETUAhVC24U0FMdkGfzoxK3Dr8A==",
-      "dev": true,
+      "version": "3.1090.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1090.0.tgz",
+      "integrity": "sha512-JjmuzG6XZG9vQFZ1Ob6kxJHz9U+x4Yxz+r717HeyYItRp+xRrGLNI5IggLDa9OfeYhq6mHJTZ6QMlyLI4EWK6w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.4",
-        "@aws-sdk/credential-provider-node": "^3.972.2",
-        "@aws-sdk/dynamodb-codec": "^3.972.4",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.2",
-        "@aws-sdk/middleware-host-header": "^3.972.2",
-        "@aws-sdk/middleware-logger": "^3.972.2",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.2",
-        "@aws-sdk/middleware-user-agent": "^3.972.4",
-        "@aws-sdk/region-config-resolver": "^3.972.2",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.2",
-        "@aws-sdk/util-user-agent-node": "^3.972.2",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.975.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.975.0.tgz",
-      "integrity": "sha512-HpgJuleH7P6uILxzJKQOmlHdwaCY+xYC6VgRDzlwVEqU/HXjo4m2gOAyjUbpXlBOCWfGgMUzfBlNJ9z3MboqEQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.1",
-        "@aws-sdk/middleware-host-header": "^3.972.1",
-        "@aws-sdk/middleware-logger": "^3.972.1",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
-        "@aws-sdk/middleware-user-agent": "^3.972.2",
-        "@aws-sdk/region-config-resolver": "^3.972.1",
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.1",
-        "@aws-sdk/util-user-agent-node": "^3.972.1",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.21.1",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.11",
-        "@smithy/middleware-retry": "^4.4.27",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.12",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.26",
-        "@smithy/util-defaults-mode-node": "^4.2.29",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/dynamodb-codec": "^3.973.33",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.25",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -281,24 +67,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.4.tgz",
-      "integrity": "sha512-8Rk+kPP74YiR47x54bxYlKZswsaSh0a4XvvRUMLvyS/koNawhsGu/+qSZxREqUeTO+GkKpFvSQIsAZR+deUP+g==",
-      "dev": true,
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/xml-builder": "^3.972.2",
-        "@smithy/core": "^3.22.0",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -306,16 +86,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.2.tgz",
-      "integrity": "sha512-wzH1EdrZsytG1xN9UHaK12J9+kfrnd2+c8y0LVoS4O4laEjPoie1qVK3k8/rZe7KOtvULzyMnO3FT4Krr9Z0Dg==",
-      "dev": true,
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.2",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -323,21 +102,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.4.tgz",
-      "integrity": "sha512-OC7F3ipXV12QfDEWybQGHLzoeHBlAdx/nLzPfHP0Wsabu3JBffu5nlzSaJNf7to9HGtOW8Bpu8NX0ugmDrCbtw==",
-      "dev": true,
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.4",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.10",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -345,25 +120,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.2.tgz",
-      "integrity": "sha512-Jrb8sLm6k8+L7520irBrvCtdLxNtrG7arIxe9TCeMJt/HxqMGJdbIjw8wILzkEHLMIi4MecF2FbXCln7OT1Tag==",
-      "dev": true,
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.2",
-        "@aws-sdk/credential-provider-env": "^3.972.2",
-        "@aws-sdk/credential-provider-http": "^3.972.3",
-        "@aws-sdk/credential-provider-login": "^3.972.2",
-        "@aws-sdk/credential-provider-process": "^3.972.2",
-        "@aws-sdk/credential-provider-sso": "^3.972.2",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.2",
-        "@aws-sdk/nested-clients": "3.975.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -371,19 +144,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.2.tgz",
-      "integrity": "sha512-mlaw2aiI3DrimW85ZMn3g7qrtHueidS58IGytZ+mbFpsYLK5wMjCAKZQtt7VatLMtSBG/dn/EY4njbnYXIDKeQ==",
-      "dev": true,
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.2",
-        "@aws-sdk/nested-clients": "3.975.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -391,23 +161,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.3.tgz",
-      "integrity": "sha512-iu+JwWHM7tHowKqE+8wNmI3sM6mPEiI9Egscz2BEV7adyKmV95oR9tBO4VIOl72FGDi7X9mXg19VtqIpSkEEsA==",
-      "dev": true,
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.2",
-        "@aws-sdk/credential-provider-http": "^3.972.4",
-        "@aws-sdk/credential-provider-ini": "^3.972.2",
-        "@aws-sdk/credential-provider-process": "^3.972.2",
-        "@aws-sdk/credential-provider-sso": "^3.972.2",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.2",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -415,17 +183,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.2.tgz",
-      "integrity": "sha512-NLKLTT7jnUe9GpQAVkPTJO+cs2FjlQDt5fArIYS7h/Iw/CvamzgGYGFRVD2SE05nOHCMwafUSi42If8esGFV+g==",
-      "dev": true,
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.2",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -433,19 +199,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.2.tgz",
-      "integrity": "sha512-YpwDn8g3gCGUl61cCV0sRxP2pFIwg+ZsMfWQ/GalSyjXtRkctCMFA+u0yPb/Q4uTfNEiya1Y4nm0C5rIHyPW5Q==",
-      "dev": true,
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.975.0",
-        "@aws-sdk/core": "^3.973.2",
-        "@aws-sdk/token-providers": "3.975.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -453,18 +217,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.2.tgz",
-      "integrity": "sha512-x9DAiN9Qz+NjJ99ltDiVQ8d511M/tuF/9MFbe2jUgo7HZhD6+x4S3iT1YcP07ndwDUjmzKGmeOEgE24k4qvfdg==",
-      "dev": true,
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.2",
-        "@aws-sdk/nested-clients": "3.975.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -472,31 +234,24 @@
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.972.4.tgz",
-      "integrity": "sha512-QuSczrnayo5GR7+c5SQmhyVtCnMb9zhTxfLvIzFrf/gWXDcZbFeRc5qO86ahH+QNcMzin+k00bPB4MoTvnR04Q==",
-      "dev": true,
+      "version": "3.973.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.33.tgz",
+      "integrity": "sha512-/awY2mG1zvTy22j4ryZL8jfWQdcuppsw17Mxw1tjG92hO+52JoFZaaTWrJIQp066t/aj4JC4II29UJb6g644vA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.4",
-        "@smithy/core": "^3.22.0",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "3.978.0"
       }
     },
     "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.2.tgz",
-      "integrity": "sha512-3L7mwqSLJ6ouZZKtCntoNF0HTYDNs1FDQqkGjoPWXcv1p0gnLotaDmLq1rIDqfu4ucOit0Re3ioLyYDUTpSroA==",
-      "dev": true,
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.9.tgz",
+      "integrity": "sha512-LFvdgq8SriaskUcjpBMDE7J2c9RmuT5v3gU36/znV71EU5DKUis4FmGFjCMelKCCViFeVrQADBAlIiOYRhEx6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "mnemonist": "0.38.3",
@@ -506,85 +261,35 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1090.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1090.0.tgz",
+      "integrity": "sha512-WAKhaitoS0m6RB5uLtWHnZryOKdT36KUrlGhrJEh5h2Sl9pkp7MqMPEEJUZ3PEmXD7qvNQN5hym/B3L+ajlGTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/util-dynamodb": "^3.996.7",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1090.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.2.tgz",
-      "integrity": "sha512-Pzz/j7wiKibTHVfPDhqjdlhL+GqP/Nsd6mbeG56uc8BsmZGHBrz5TrwLAQXE1mWBliiEDs9fsh0W62CsX/Qy1g==",
-      "dev": true,
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.25.tgz",
+      "integrity": "sha512-5G2aVPmbWC5dFI76D0vsNg2L0fgWP4uybcetf+06dzeZuRtpihnow88fOl5zm3+ABdIw27FKgyFzV4yB5Bm29Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/endpoint-cache": "^3.972.2",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.2.tgz",
-      "integrity": "sha512-42hZ8jEXT2uR6YybCzNq9OomqHPw43YIfRfz17biZjMQA4jKSQUaHIl6VvqO2Ddl5904pXg2Yd/ku78S0Ikgog==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.2.tgz",
-      "integrity": "sha512-iUzdXKOgi4JVDDEG/VvoNw50FryRCEm0qAudw12DcZoiNJWl0rN6SYVLcL1xwugMfQncCXieK5UBlG6mhH7iYA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.2.tgz",
-      "integrity": "sha512-/mzlyzJDtngNFd/rAYvqx29a2d0VuiYKN84Y/Mu9mGw7cfMOCyRK+896tb9wV6MoPRHUX7IXuKCIL8nzz2Pz5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.4.tgz",
-      "integrity": "sha512-6sU8jrSJvY/lqSnU6IYsa8SrCKwOZ4Enl6O4xVJo8RCq9Bdr5Giuw2eUaJAk9GPcpr4OFcmSFv3JOLhpKGeRZA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.4",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@smithy/core": "^3.22.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/endpoint-cache": "^3.972.9",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -592,66 +297,33 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.975.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.975.0.tgz",
-      "integrity": "sha512-OkeFHPlQj2c/Y5bQGkX14pxhDWUGUFt3LRHhjcDKsSCw6lrxKcxN3WFZN0qbJwKNydP+knL5nxvfgKiCLpTLRA==",
-      "dev": true,
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.1",
-        "@aws-sdk/middleware-host-header": "^3.972.1",
-        "@aws-sdk/middleware-logger": "^3.972.1",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
-        "@aws-sdk/middleware-user-agent": "^3.972.2",
-        "@aws-sdk/region-config-resolver": "^3.972.1",
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.1",
-        "@aws-sdk/util-user-agent-node": "^3.972.1",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.21.1",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.11",
-        "@smithy/middleware-retry": "^4.4.27",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.12",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.26",
-        "@smithy/util-defaults-mode-node": "^4.2.29",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.2.tgz",
-      "integrity": "sha512-/7vRBsfmiOlg2X67EdKrzzQGw5/SbkXb7ALHQmlQLkZh8qNgvS2G2dDC6NtF3hzFlpP3j2k+KIEtql/6VrI6JA==",
-      "dev": true,
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -659,18 +331,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.975.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.975.0.tgz",
-      "integrity": "sha512-AWQt64hkVbDQ+CmM09wnvSk2mVyH4iRROkmYkr3/lmUtFNbE2L/fnw26sckZnUcFCsHPqbkQrcsZAnTcBLbH4w==",
-      "dev": true,
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.1",
-        "@aws-sdk/nested-clients": "3.975.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -678,110 +348,40 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-      "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-      "dev": true,
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.972.0.tgz",
-      "integrity": "sha512-6JHsl1V/a1ZW8D8AFfd4R52fwZPnZ5H4U6DS8m/bWT8qad72NvbOFAC7U2cDtFs2TShqUO3TEiX/EJibtY3ijg==",
-      "dev": true,
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.7.tgz",
+      "integrity": "sha512-v+WJASG9yaW8qNM7pNSgH1PBYz5mVTf7gzKPi0NqGjLlaCtPdk6EjM1lmv03egA07iXUw6OToGYfW2w8D3kBrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.972.0",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.972.0.tgz",
-      "integrity": "sha512-U7xBIbLSetONxb2bNzHyDgND3oKGoIfmknrEVnoEU4GUSs+0augUOIn9DIWGUO2ETcRFdsRUnmx9KhPT9Ojbug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.4.tgz",
-      "integrity": "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.2.tgz",
-      "integrity": "sha512-gz76bUyebPZRxIsBHJUd/v+yiyFzm9adHbr8NykP2nm+z/rFyvQneOHajrUejtmnc5tTBeaDPL4X25TnagRk4A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.2.tgz",
-      "integrity": "sha512-vnxOc4C6AR7hVbwyFo1YuH0GB6dgJlWt8nIOOJpnzJAWJPkUMPJ9Zv2lnKsSU7TTZbhP2hEO8OZ4PYH59XFv8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
+        "@aws-sdk/client-dynamodb": "^3.1088.0"
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.2.tgz",
-      "integrity": "sha512-jGOOV/bV1DhkkUhHiZ3/1GZ67cZyOXaDb7d1rYD6ZiXf5V9tBNOcgqXwRRPvrCbYaFRa1pPMFb3ZjqjWpR3YfA==",
-      "dev": true,
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "fast-xml-parser": "5.2.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -789,10 +389,9 @@
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
-      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
-      "dev": true,
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -1029,6 +628,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@mapbox/dyno/-/dyno-1.6.3.tgz",
       "integrity": "sha512-ifgF+ndb6ScRh0DEqQUS9ntOTrPcBxsVZM+5/x3WyBbBsNHQCkpdel1zn5354gaUrOuJ9B4uEy8IDLwQt2fC/A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.7.2",
@@ -1086,54 +686,13 @@
         "geojson-normalize": "geojson-normalize"
       }
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
-      "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/config-resolver": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
-      "integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/core": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.22.0.tgz",
-      "integrity": "sha512-6vjCHD6vaY8KubeNw2Fg3EK0KLGQYdldG4fYgQmA0xSW0dJ8G2xFhSOdrlUakWVoP5JuWHtFODg3PNd/DN3FDA==",
-      "dev": true,
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
+      "integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-stream": "^4.5.10",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1141,16 +700,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
-      "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
-      "dev": true,
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.10.tgz",
+      "integrity": "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1158,160 +714,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
-      "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
-      "dev": true,
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.7.tgz",
+      "integrity": "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
-      "integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
-      "integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
-      "integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.12.tgz",
-      "integrity": "sha512-9JMKHVJtW9RysTNjcBZQHDwB0p3iTP6B1IfQV4m+uCevkVd/VuLgwfqk5cnI4RHcp4cPwoIvxQqN4B1sxeHo8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.22.0",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.29",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.29.tgz",
-      "integrity": "sha512-bmTn75a4tmKRkC5w61yYQLb3DmxNzB8qSVu9SbTYqW6GAL0WXO2bDZuMAn/GJSbOdHEdjZvWxe+9Kk015bw6Cg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/uuid": "^1.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
-      "integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
-      "integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
-      "integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1319,100 +728,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.8.tgz",
-      "integrity": "sha512-q9u+MSbJVIJ1QmJ4+1u+cERXkrhuILCBDsJUBAW1MPE6sFonbCNaegFuwW9ll8kh5UdyY3jOkoOGlc7BesoLpg==",
-      "dev": true,
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.7.tgz",
+      "integrity": "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/property-provider": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
-      "integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
-      "integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
-      "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
-      "integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
-      "integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
-      "integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1420,38 +742,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
-      "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
-      "dev": true,
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.6.tgz",
+      "integrity": "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/smithy-client": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.1.tgz",
-      "integrity": "sha512-SERgNg5Z1U+jfR6/2xPYjSEHY1t3pyTHC/Ma3YQl6qWtmiL42bvNId3W/oMUWIwu7ekL2FMPdqAmwbQegM7HeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.22.0",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.10",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1459,260 +756,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
-      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/url-parser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
-      "integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.28",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.28.tgz",
-      "integrity": "sha512-/9zcatsCao9h6g18p/9vH9NIi5PSqhCkxQ/tb7pMgRFnqYp9XUOyOlGPDMHzr8n5ih6yYgwJEY2MLEobUgi47w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.31",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.31.tgz",
-      "integrity": "sha512-JTvoApUXA5kbpceI2vuqQzRjeTbLpx1eoa5R/YEZbTgtxvIB7AQZxFJ0SEyfCpgPCyVV9IT7we+ytSeIB3CyWA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
-      "integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-middleware": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
-      "integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
-      "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream": {
-      "version": "4.5.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.10.tgz",
-      "integrity": "sha512-jbqemy51UFSZSp2y0ZmRfckmrzuKww95zT9BYMmuJ8v3altGcqjwoV1tzpOwuHaKrwQrCjIzOib499ymr2f98g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-waiter": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.8.tgz",
-      "integrity": "sha512-n+lahlMWk+aejGuax7DPWtqav8HYnWxQwR+LCG2BgCUmaGcTe9qZCFsmw8TMg9iG75HOwhrJCX9TCJRLH+Yzqg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/uuid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
-      "dev": true,
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2102,6 +1148,7 @@
       "version": "2.1693.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1693.0.tgz",
       "integrity": "sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2413,6 +1460,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2443,6 +1491,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -2500,10 +1549,9 @@
       }
     },
     "node_modules/bowser": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
-      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
-      "dev": true,
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -2576,6 +1624,7 @@
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.0.2",
@@ -3713,6 +2762,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/duplexer2": {
@@ -4510,6 +3560,7 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -4549,6 +3600,7 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "duplexer": "~0.1.1",
@@ -4564,6 +3616,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
@@ -4737,25 +3790,6 @@
       "integrity": "sha512-hYsfI0s4lfQ2rHVFKXwAr/L/ZSbq9TZwgXtZqW7ANcn9o9GKvcbWxOnxx7jykXf/Ezv1V8TvaBEKcGK7DWKX5A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^2.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
     },
     "node_modules/figures": {
       "version": "1.7.0",
@@ -4942,6 +3976,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fs-constants": {
@@ -4951,37 +3986,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/fs-extra": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.6.4.tgz",
-      "integrity": "sha512-5rU898vl/Z948L+kkJedbmo/iltzmiF5bn/eEk0j/SgrPpI+Ydau9xlJPicV7Av2CHYBGz5LAlwTnBU80j1zPQ==",
-      "dev": true,
-      "dependencies": {
-        "jsonfile": "~1.0.1",
-        "mkdirp": "0.3.x",
-        "ncp": "~0.4.2",
-        "rimraf": "~2.2.0"
-      }
-    },
-    "node_modules/fs-extra/node_modules/mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fs-extra/node_modules/rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "rimraf": "bin.js"
-      }
     },
     "node_modules/fs-readdir-recursive": {
       "version": "0.1.2",
@@ -6116,6 +5120,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6775,6 +5780,7 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.6.0"
@@ -6881,12 +5887,6 @@
       "bin": {
         "json5": "lib/cli.js"
       }
-    },
-    "node_modules/jsonfile": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.0.1.tgz",
-      "integrity": "sha512-KbsDJNRfRPF5v49tMNf9sqyyGqGLBcz1v5kZT01kG5ns5mQSltwxCKVmUzVKtEinkUnTDtSrp6ngWpV7Xw0ZlA==",
-      "dev": true
     },
     "node_modules/jsonify": {
       "version": "0.0.1",
@@ -7755,7 +6755,8 @@
     "node_modules/map-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
+      "dev": true
     },
     "node_modules/map-visit": {
       "version": "1.0.0",
@@ -8127,30 +7128,10 @@
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "obliterator": "^1.6.1"
       }
-    },
-    "node_modules/mock-aws-s3": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/mock-aws-s3/-/mock-aws-s3-0.2.7.tgz",
-      "integrity": "sha512-7hzF2E+8n4DET6xOrWq6tba7Us05k9wVN7HMSSmRMqMuuvFqvHcG993FIr1vcBLvLEqNgO107gtJo/MFHPnE/A==",
-      "dev": true,
-      "dependencies": {
-        "fs-extra": "0.6.4",
-        "underscore": "1.5.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/mock-aws-s3/node_modules/underscore": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
-      "integrity": "sha512-yejOFsRnTJs0N9CK5Apzf6maDO2djxGoLLrlZlvGs2o9ZQuhIhDL18rtFyy4FBIbOkzA6+4hDgXbgz5EvDQCXQ==",
-      "dev": true
     },
     "node_modules/mock-property": {
       "version": "1.0.3",
@@ -8397,16 +7378,6 @@
       "deprecated": "This module relies on Node.js's internals and will break at some point. Do not use it, and update to graceful-fs@4.x.",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ncp": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-      "integrity": "sha512-PfGU8jYWdRl4FqJfCy0IzbkGyFHntfWygZg46nFk/dJD/XRrk2cj0SsKSX9n5u5gE0E0YfEpKWrEkfjnlZSTXA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "ncp": "bin/ncp"
-      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -11288,7 +10259,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/once": {
@@ -11419,6 +10389,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/parallel-stream/-/parallel-stream-1.1.2.tgz",
       "integrity": "sha512-qKaFRMDPnH9VXuAic8sgLgzZxG9CIxKJDJhlZI8dGGqZ+4ivSDasudYZ1Tx1How8QiuwZLipr1PK+S62LXLSIA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/parents": {
@@ -11542,6 +10513,7 @@
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
       "license": [
         "MIT",
         "Apache2"
@@ -11819,6 +10791,7 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -12750,6 +11723,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/semver": {
@@ -13302,6 +12276,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "through": "2"
@@ -13575,6 +12550,7 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "duplexer": "~0.1.1"
@@ -13812,19 +12788,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/subarg": {
       "version": "1.0.0",
@@ -14142,6 +13105,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2": {
@@ -14385,7 +13349,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
@@ -14691,6 +13654,7 @@
       "version": "1.13.7",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
       "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unherit": {
@@ -14874,6 +13838,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "1.3.2",
@@ -14884,6 +13849,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/use": {
@@ -14913,6 +13879,7 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -14932,6 +13899,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
       "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -15375,6 +14343,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
       "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
@@ -15388,6 +14357,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "engines": {
     "node": ">=20"
-  }
+  },
   "scripts": {
     "pretest": "eslint index.js lib test/*.js",
     "test": "nyc tape test/*.test.js",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "geojson-fixtures": "0.1.0",
     "geojson-random": "^0.2.2",
     "geojson-stream": "0.0.0",
-    "mock-aws-s3": "^0.2.1",
     "nyc": "^6.4.4",
     "tape": "^4.6.3"
   }

--- a/package.json
+++ b/package.json
@@ -34,18 +34,16 @@
     "@aws-sdk/client-dynamodb": "^3.0.0",
     "@aws-sdk/lib-dynamodb": "^3.0.0",
     "@aws-sdk/util-dynamodb": "^3.0.0",
+    "@paralleldrive/cuid2": "^2.2.2",
     "buffer-from": "^0.1.1",
-    "cuid": "1.2.4",
     "geobuf": "^3.0.0",
     "@mapbox/geojson-extent": "^1.0.1",
-    "geojson-normalize": "0.0.0",
+    "@mapbox/geojson-normalize": "^0.0.1",
     "lodash": "^4.17.23",
     "minimist": "^1.2.8",
     "pbf": "^3.0.4",
-    "queue-async": "~1.0.7",
-    "sphericalmercator": "^1.0.3",
-    "through2": "^2.0.0",
-    "tilebelt": "^0.5.2"
+    "queue-async": "^1.2.1",
+    "through2": "^2.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A library for storing and searching geographic features",
   "main": "index.js",
   "engines": {
-    "node": ">=18"
-  },
+    "node": ">=20"
+  }
   "scripts": {
     "pretest": "eslint index.js lib test/*.js",
     "test": "nyc tape test/*.test.js",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@mapbox/cardboard",
-  "version": "3.0.6",
+  "version": "4.0.0",
   "description": "A library for storing and searching geographic features",
   "main": "index.js",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "pretest": "eslint index.js lib test/*.js",
     "test": "nyc tape test/*.test.js",
@@ -28,10 +31,11 @@
   },
   "homepage": "https://github.com/mapbox/cardboard",
   "dependencies": {
-    "aws-sdk": "2.x",
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
+    "@aws-sdk/util-dynamodb": "^3.0.0",
     "buffer-from": "^0.1.1",
     "cuid": "1.2.4",
-    "@mapbox/dyno": "^1.6.3",
     "geobuf": "^3.0.0",
     "@mapbox/geojson-extent": "^1.0.1",
     "geojson-normalize": "0.0.0",

--- a/test/batch.test.js
+++ b/test/batch.test.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var fixtures = require('./fixtures');
 var states = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'data', 'states.geojson'), 'utf8'));
+var paginateScan = require('@aws-sdk/lib-dynamodb').paginateScan;
 
 var mainTable = require('@mapbox/dynamodb-test')(require('tape'), 'cardboard', require('../lib/main-table.json'));
 
@@ -11,38 +12,39 @@ var config = {
     endpoint: 'http://localhost:4567'
 };
 
-function unprocessableDyno(table) {
+// A fake DynamoDBDocumentClient whose batch operations always report every
+// requested item/key as unprocessed, to exercise cardboard's `pending` handling.
+function unprocessableDynamoDb(table) {
     return {
-        config: { params: { TableName: table} },
-        batchGetItemRequests: function(params) {
-            return {
-                sendAll: function(rate, callback) {
-                    setTimeout(function() {
-                        callback(null, [{
-                            UnprocessedKeys: params.RequestItems
-                        }]);
-                    }, 0);
-                }
+        send: function(command) {
+            var requestItems = command.input.RequestItems[table];
+            if (requestItems && requestItems.Keys) {
+                return Promise.resolve({ UnprocessedKeys: command.input.RequestItems });
             }
-        },
-        batchWriteItemRequests: function(params) {
-            return {
-                sendAll: function(rate, callback) {
-                    setTimeout(function() {
-                        callback(null, [{
-                            UnprocessedItems: params
-                        }]);
-                    }, 0);
-                }
-            }
+            return Promise.resolve({ UnprocessedItems: command.input.RequestItems });
         }
-    } 
+    };
 }
 
-var cardboard = require('../')(config);     
+function scanAll(callback) {
+    var paginator = paginateScan({ client: config.dynamodb }, { TableName: config.mainTable });
+    var records = [];
+
+    function step() {
+        paginator.next().then(function(result) {
+            if (result.done) return callback(null, records);
+            records = records.concat(result.value.Items || []);
+            step();
+        }, callback);
+    }
+
+    step();
+}
+
+var cardboard = require('../')(config);
 var unprocessableCardboard = require('..')({
     mainTable: 'features',
-    dyno: unprocessableDyno('features')
+    dynamodb: unprocessableDynamoDb('features')
 });
 
 mainTable.test('[batch] put', function(assert) {
@@ -55,20 +57,17 @@ mainTable.test('[batch] put', function(assert) {
             return hasId;
         }, true), 'all returned features have ids');
 
-        var records = [];
-        config.dyno.scanStream()
-            .on('data', function(d) { records.push(d); })
-            .on('error', function(err) { throw err; })
-            .on('end', function() {
-                assert.equal(records.length, states.features.length, 'inserted all the features');
+        scanAll(function(err, records) {
+            if (err) throw err;
+            assert.equal(records.length, states.features.length, 'inserted all the features');
 
-                assert.ok(records.reduce(function(inDataset, record) {
-                    if (record.key.indexOf('states!') !== 0) inDataset = false;
-                    return inDataset;
-                }, true), 'all records in the right dataset');
+            assert.ok(records.reduce(function(inDataset, record) {
+                if (record.key.indexOf('states!') !== 0) inDataset = false;
+                return inDataset;
+            }, true), 'all records in the right dataset');
 
-                assert.end();
-            });
+            assert.end();
+        });
     });
 });
 
@@ -122,8 +121,7 @@ mainTable.test('[batch] del', function(assert) {
         });
         cardboard.del(ids, 'states', function(err) {
             assert.ifError(err, 'success');
-            var records = [];
-            config.dyno.scanStream().on('data', function(d) { records.push(d); }).on('end', function() {
+            scanAll(function(err, records) {
                 if (err) throw err;
                 assert.equal(records.length, 0, 'deleted all the records');
                 assert.end();

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -33,8 +33,6 @@ mainTable.test('[cli] config via env', features, function(assert) {
         env: _.extend({
             CardboardRegion: 'region',
             CardboardMainTable: 'features',
-            CardboardBucket: 'bucket',
-            CardboardPrefix: 'prefix',
             CardboardEndpoint: 'http://localhost:4567'
         }, process.env)
     };
@@ -51,8 +49,6 @@ mainTable.test('[cli] config via params', features, function(assert) {
         cmd,
         '--region', 'region',
         '--mainTable', config.mainTable,
-        '--bucket', 'bucket',
-        '--prefix', 'prefix',
         '--endpoint', 'http://localhost:4567',
         'invalid-command'
     ];
@@ -68,8 +64,6 @@ mainTable.test('[cli] config fail', features, function(assert) {
         cmd,
         '--mainTable', config.mainTable,
         '--searchTable', config.searchTable,
-        '--bucket', 'bucket',
-        '--prefix', 'prefix',
         '--endpoint', 'http://localhost:4567',
         'invalid-command'
     ];
@@ -85,8 +79,6 @@ mainTable.test('[cli] get', features, function(assert) {
         '--region', 'region',
         '--mainTable', config.mainTable,
         '--searchTable', config.searchTable,
-        '--bucket', 'test',
-        '--prefix', 'test',
         '--endpoint', 'http://localhost:4567',
         'get', 'test', '\'new-hampshire\''
     ];

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,6 +1,7 @@
 var Cardboard = require('../');
 var _ = require('lodash');
-var Dyno = require('@mapbox/dyno');
+var DynamoDBClient = require('@aws-sdk/client-dynamodb').DynamoDBClient;
+var DynamoDBDocumentClient = require('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
 
 var mainTable = require('@mapbox/dynamodb-test')(require('tape'), 'cardboard', require('../lib/main-table.json'));
 
@@ -10,19 +11,25 @@ var config = {
     endpoint: 'http://localhost:4567'
 };
 
-mainTable.test('pass preconfigured dyno object', function(assert) {
+mainTable.test('pass preconfigured dynamodb client', function(assert) {
 
-    var omitConfig = _.omit(config, ['accessKeyId', 'secretAccessKey', 'table', 'endpoint', 'region']);
+    var omitConfig = _.omit(config, ['accessKeyId', 'secretAccessKey', 'endpoint', 'region']);
 
     var featuresConfig = {
         accessKeyId: 'fake',
         secretAccessKey: 'fake',
         region: 'us-east-1',
-        table: 'features',
         endpoint: 'http://localhost:4567'
     };
 
-    omitConfig.dyno = Dyno(featuresConfig, featuresConfig);
+    omitConfig.dynamodb = DynamoDBDocumentClient.from(new DynamoDBClient({
+        region: featuresConfig.region,
+        endpoint: featuresConfig.endpoint,
+        credentials: {
+            accessKeyId: featuresConfig.accessKeyId,
+            secretAccessKey: featuresConfig.secretAccessKey
+        }
+    }));
     var cardboard = Cardboard(omitConfig);
     var geojson = {type: 'Feature', properties: {}, geometry: {type: 'Point', coordinates:[1, 2]}};
 

--- a/test/indexing.test.js
+++ b/test/indexing.test.js
@@ -3,6 +3,7 @@ var Cardboard = require('../');
 var Pbf = require('pbf');
 var geobuf = require('geobuf');
 var fixtures = require('./fixtures');
+var GetCommand = require('@aws-sdk/lib-dynamodb').GetCommand;
 
 var mainTable = require('@mapbox/dynamodb-test')(require('tape'), 'cardboard', require('../lib/main-table.json'));
 
@@ -127,9 +128,8 @@ mainTable.test('[indexing] insert wildly precise feature', function(assert) {
     cardboard.put(d, 'default', function(err, res) {
         assert.ifError(err, 'inserted without error');
         var key = utils.createFeatureKey('default', res.features[0].id);
-        config.dyno.getItem({ Key: key}, function(err, data) {
+        config.dynamodb.send(new GetCommand({ TableName: config.mainTable, Key: key })).then(function(data) {
             var item = data.Item;
-            assert.ifError(err, 'got item');
             var feature = utils.decodeBuffer(item.val);
 
             var fLng = feature.geometry.coordinates[0].toString();
@@ -144,6 +144,9 @@ mainTable.test('[indexing] insert wildly precise feature', function(assert) {
             assert.equal(fLng, dLng.slice(0, 8));
             assert.equal(fLat, dLat.slice(0, 8));
 
+            assert.end();
+        }, function(err) {
+            assert.ifError(err, 'got item');
             assert.end();
         });
     });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,7 +1,9 @@
 var Dynalite = require('dynalite');
 var Cardboard = require('../');
-var fakeAWS = require('mock-aws-s3');
 var queue = require('queue-async');
+var DynamoDBClient = require('@aws-sdk/client-dynamodb').DynamoDBClient;
+var ListTablesCommand = require('@aws-sdk/client-dynamodb').ListTablesCommand;
+var DeleteTableCommand = require('@aws-sdk/client-dynamodb').DeleteTableCommand;
 var dynalite;
 
 var config = module.exports.config = {
@@ -9,19 +11,14 @@ var config = module.exports.config = {
     secretAccessKey: 'fake',
     mainTable: 'features',
     endpoint: 'http://localhost:4567',
-    bucket: 'test',
-    prefix: 'test',
-    region: 'us-east-1',
-    s3: fakeAWS.S3() // only for mocking s3
+    region: 'us-east-1'
 };
 
-var dynoConfig = {
-    table: 'fake',
+var client = new DynamoDBClient({
     region: 'us-east-1',
-    endpoint: 'http://localhost:4567'
-};
-
-var dyno  = require('@mapbox/dyno')(dynoConfig);
+    endpoint: 'http://localhost:4567',
+    credentials: { accessKeyId: 'fake', secretAccessKey: 'fake' }
+});
 
 module.exports.setup = function(done) {
     dynalite = Dynalite({
@@ -37,10 +34,12 @@ module.exports.setup = function(done) {
 };
 
 module.exports.teardown = function(done) {
-    dyno.listTables(function(err, tables) {
+    client.send(new ListTablesCommand({})).then(function(tables) {
         var q = queue();
         tables.TableNames.forEach(function(table) {
-            q.defer(dyno.deleteTable, { TableName: table });
+            q.defer(function(name, cb) {
+                client.send(new DeleteTableCommand({ TableName: name })).then(function() { cb(); }, cb);
+            }, table);
         });
 
         q.awaitAll(function(err) {
@@ -49,5 +48,5 @@ module.exports.teardown = function(done) {
                 done(err);
             });
         });
-    });
+    }, done);
 };

--- a/test/stream-helper.test.js
+++ b/test/stream-helper.test.js
@@ -1,5 +1,5 @@
 var test = require('tape');
-var Dyno = require('@mapbox/dyno');
+var marshall = require('@aws-sdk/util-dynamodb').marshall;
 var streamHelper = require('../lib/stream-helper');
 
 test('handlers removes', function(assert) {
@@ -64,7 +64,7 @@ test('removes actions we dont want', function(assert) {
 
 function toEvent(action, records) {
     var out = records.map(function(mainRecord) {
-        var serialized = JSON.parse(Dyno.serialize(mainRecord));
+        var serialized = marshall(mainRecord);
         var record = { eventName: action };
         record.dynamodb = {};
         record.dynamodb.OldImage = action !== 'INSERT' ? serialized : undefined;

--- a/test/table.test.js
+++ b/test/table.test.js
@@ -6,16 +6,19 @@ var dynalite = require('dynalite')({
     updateTableMs: 0,
     deleteTableMs: 0
 });
+var DynamoDBClient = require('@aws-sdk/client-dynamodb').DynamoDBClient;
+var ListTablesCommand = require('@aws-sdk/client-dynamodb').ListTablesCommand;
+var DeleteTableCommand = require('@aws-sdk/client-dynamodb').DeleteTableCommand;
 
 var config = {
     region: 'fake',
     endpoint: 'http://localhost:4567'
 };
 
-var dyno = require('@mapbox/dyno')({
-    table: 'fake',
+var client = new DynamoDBClient({
     region: 'fake',
-    endpoint: 'http://localhost:4567'
+    endpoint: 'http://localhost:4567',
+    credentials: { accessKeyId: 'fake', secretAccessKey: 'fake' }
 });
 
 function before() {
@@ -29,13 +32,11 @@ function before() {
 
 function after() {
     test('tearing down tables', function(assert) {
-        dyno.listTables(function(err, tables) {
-            assert.ifError(err, 'found tables');
-            if (err) return assert.end(err);
+        client.send(new ListTablesCommand({})).then(function(tables) {
             var q = queue();
             tables.TableNames.forEach(function(name) {
                 q.defer(function(done) {
-                    dyno.deleteTable({TableName: name}, done);  
+                    client.send(new DeleteTableCommand({ TableName: name })).then(function() { done(); }, done);
                 });
             });
 
@@ -43,6 +44,9 @@ function after() {
                 if (err) return assert.end(err);
                 dynalite.close(function(err) { assert.end(err); });
             });
+        }, function(err) {
+            assert.ifError(err, 'found tables');
+            assert.end(err);
         });
     });
 }
@@ -53,12 +57,11 @@ test('[tables] createTable - match config name', function(assert) {
     var cardboard = require('..')(_.extend({ mainTable: 'features' }, config));
     cardboard.createTable(function(err) {
         assert.ifError(err, 'success');
-  
-        dyno.listTables(function(err, tables) {
-            if (err) throw err;
+
+        client.send(new ListTablesCommand({})).then(function(tables) {
             assert.deepEqual(tables.TableNames, ['features'], 'created table');
             assert.end();
-        });
+        }, function(err) { throw err; });
     });
 });
 
@@ -69,12 +72,11 @@ test('[tables] createTable - match config name, with difference names', function
     var cardboard = require('..')(_.extend({ mainTable: 'first' }, config));
     cardboard.createTable(function(err) {
         assert.ifError(err, 'success');
-  
-        dyno.listTables(function(err, tables) {
-            if (err) throw err;
+
+        client.send(new ListTablesCommand({})).then(function(tables) {
             assert.deepEqual(tables.TableNames, ['first'], 'created table');
             assert.end();
-        });
+        }, function(err) { throw err; });
     });
 });
 


### PR DESCRIPTION
This switches dyno out for direct aws sdk v3 clients.

This version will have breaking changes due to the different underlying clients. (noted in the changelog)
There were also some unused S3 params that I cleaned up.